### PR TITLE
Use this firefox icon until/if the new one takes its place?

### DIFF
--- a/apps/scalable/firefox_old.svg
+++ b/apps/scalable/firefox_old.svg
@@ -1,0 +1,5793 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="256"
+   height="256"
+   viewBox="0 0 67.733332 67.733335"
+   version="1.1"
+   id="svg1488"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="firefoxsuruguidelines.svg">
+  <defs
+     id="defs1482">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1025">
+      <path
+         id="path1027"
+         d="M 111.94141,84 C 99.359506,84.145 90.1531,83.713998 82.625,87.867188 c -3.7641,2.0768 -6.751838,5.574737 -8.398438,9.960937 C 72.580062,102.21433 72,107.4241 72,114 v 42 h 160 v -26 c 0,-6.5759 -0.57996,-11.78566 -2.22656,-16.17188 -0.205,-0.5455 -0.47919,-1.03993 -0.74219,-1.54296 -0.1,-0.1848 -0.17844,-0.38051 -0.27344,-0.56641 -1.727,-3.38752 -4.25471,-6.14522 -7.38281,-7.87109 C 213.8463,99.694146 204.64049,100.1454 192.05859,100 H 192 151.66797 L 135.45312,84 h -23.49218 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e3dfd5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.00000048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-5">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-6"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-9">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-3"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-3">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-67"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-53">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-5"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-6">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-2"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-91">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-27"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1025-0">
+      <path
+         style="opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 329.9375,32 C 475.2348,32 496,52.71323 496,197.875 v 116.25 C 496,459.28618 475.2348,480 329.9375,480 H 182.0625 C 36.7652,480 16,459.28618 16,314.125 V 197.875 C 16,52.71323 36.7652,32 182.0625,32 Z"
+         id="path1027-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4277-8">
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.81999972;fill:#88b637;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect4279-6"
+         width="512"
+         height="512"
+         x="5.5999999e-07"
+         y="0"
+         ry="1" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient3650-7-9">
+      <stop
+         style="stop-color:#5884f4;stop-opacity:1"
+         offset="0"
+         id="stop4366" />
+      <stop
+         id="stop4368"
+         offset="1"
+         style="stop-color:#80a3fa;stop-opacity:1" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-36">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-0"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath983">
+      <path
+         id="path985"
+         d="M 115.03125,44 C 42.3826,44 32,54.356615 32,126.9375 v 58.125 C 32,257.64309 42.3826,268 115.03125,268 H 152 V 44 Z"
+         style="opacity:1;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-62">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-61"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath949">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path951"
+         d="M 329.9375,32 C 475.2348,32 496,52.71323 496,197.875 v 116.25 C 496,459.28618 475.2348,480 329.9375,480 H 182.0625 C 36.7652,480 16,459.28618 16,314.125 V 197.875 C 16,52.71323 36.7652,32 182.0625,32 Z"
+         style="opacity:1;fill:#eab305;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath954">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path952"
+         d="M 329.9375,32 C 475.2348,32 496,52.71323 496,197.875 v 116.25 C 496,459.28618 475.2348,480 329.9375,480 H 182.0625 C 36.7652,480 16,459.28618 16,314.125 V 197.875 C 16,52.71323 36.7652,32 182.0625,32 Z"
+         style="opacity:1;fill:#eab305;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-8">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-7"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-92">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-02"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-361">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-29"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1079">
+      <circle
+         cx="213.84277"
+         cy="146"
+         r="55"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1083);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:7.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="circle1081"
+         transform="scale(-1,1)" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath984">
+      <circle
+         cx="213.84277"
+         cy="146"
+         r="55"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1083);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:7.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="circle982"
+         transform="scale(-1,1)" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath988">
+      <circle
+         cx="213.84277"
+         cy="146"
+         r="55"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1083);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:7.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="circle986"
+         transform="scale(-1,1)" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath992">
+      <circle
+         cx="213.84277"
+         cy="146"
+         r="55"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1083);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:7.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="circle990"
+         transform="scale(-1,1)" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-31">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-9"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1205">
+      <path
+         id="path1207"
+         d="M 115.03125,44 C 42.3826,44 32,54.356615 32,126.9375 v 58.125 c 0,13.772 0.379014,25.29352 1.482422,34.9375 H 270.51758 C 271.62099,210.35602 272,198.8345 272,185.0625 v -58.125 C 272,54.356615 261.6174,44 188.96875,44 Z"
+         style="opacity:1;fill:#f1f0e9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-4">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-78"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-45">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-03"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-61">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-06"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1064">
+      <path
+         style="opacity:1;fill:#a3dbf0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 115.03125,44 C 42.3826,44 32,54.356615 32,126.9375 v 58.125 c 0,10.16582 0.217657,19.07051 0.767578,26.9375 3.376331,48.30069 19.790377,56 82.263672,56 h 73.9375 c 62.4733,0 78.88734,-7.69931 82.26367,-56 C 271.78234,204.13301 272,195.22832 272,185.0625 v -58.125 C 272,54.356615 261.6174,44 188.96875,44 Z"
+         id="path1066"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-32">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-061"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath947">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path949"
+         d="m 191.43333,45.066672 c 77.49189,0 88.56666,11.047056 88.56666,88.466668 v 62 C 279.99999,272.95263 268.92522,284 191.43333,284 H 112.56666 C 35.074773,284 23.999999,272.95263 23.999999,195.53334 v -62 c 0,-77.419612 11.074774,-88.466668 88.566661,-88.466668 z"
+         style="opacity:1;fill:#a4c1f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-55">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-4"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath991">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path993"
+         d="M 188.96875,44 C 261.6174,44 272,54.356615 272,126.9375 v 58.125 C 272,257.64309 261.6174,268 188.96875,268 h -73.9375 C 42.3826,268 32,257.64309 32,185.0625 v -58.125 C 32,54.356615 42.3826,44 115.03125,44 Z"
+         style="opacity:1;fill:#6dc7f1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath978">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path976"
+         d="M 188.96875,44 C 261.6174,44 272,54.356615 272,126.9375 v 58.125 C 272,257.64309 261.6174,268 188.96875,268 h -73.9375 C 42.3826,268 32,257.64309 32,185.0625 v -58.125 C 32,54.356615 42.3826,44 115.03125,44 Z"
+         style="opacity:1;fill:#6dc7f1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath942">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path944"
+         d="M 188.96875,44 C 261.6174,44 272,54.356615 272,126.9375 v 58.125 C 272,257.64309 261.6174,268 188.96875,268 h -73.9375 C 42.3826,268 32,257.64309 32,185.0625 v -58.125 C 32,54.356615 42.3826,44 115.03125,44 Z"
+         style="display:inline;opacity:1;fill:#46a926;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-7">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-65"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <radialGradient
+       id="radialGradient3322"
+       gradientUnits="userSpaceOnUse"
+       cy="-2.0645001"
+       cx="26.617001"
+       gradientTransform="matrix(-4.8906e-8,-2.8515,3.7557,0,674.00149,398.26285)"
+       r="23">
+      <stop
+         id="stop2749"
+         style="stop-color:#d280b9;stop-opacity:1"
+         offset="0" />
+      <stop
+         offset="0.52913231"
+         style="stop-color:#b549b5;stop-opacity:1"
+         id="stop4269" />
+      <stop
+         id="stop2755"
+         style="stop-color:#8940a8;stop-opacity:1"
+         offset="1" />
+    </radialGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-69">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-37"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient4284"
+       y2="48.209999"
+       gradientUnits="userSpaceOnUse"
+       y1="463.79001"
+       gradientTransform="translate(-1.6559e-6,2.886)"
+       x2="309.45001"
+       x1="309.45001">
+      <stop
+         id="stop4349"
+         style="stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop4355"
+         offset=".49620" />
+      <stop
+         id="stop4351"
+         style="stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <filter
+       id="filter4300"
+       style="color-interpolation-filters:sRGB"
+       height="1.192"
+       width="1.192"
+       y="-0.096001998"
+       x="-0.095997997">
+      <feGaussianBlur
+         id="feGaussianBlur4302"
+         stdDeviation="16.623603" />
+    </filter>
+    <filter
+       id="filter4315"
+       style="color-interpolation-filters:sRGB"
+       height="1.024"
+       width="1.024"
+       y="-0.012"
+       x="-0.012">
+      <feGaussianBlur
+         id="feGaussianBlur4317"
+         stdDeviation="2.0779504" />
+    </filter>
+    <linearGradient
+       id="linearGradient4257"
+       y2="154.86"
+       gradientUnits="userSpaceOnUse"
+       y1="460.98001"
+       x2="464"
+       x1="126.19">
+      <stop
+         id="stop4273"
+         style="stop-color:#d9eabb"
+         offset="0" />
+      <stop
+         id="stop4271"
+         style="stop-color:#f0f7e5"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4432"
+       y2="255.67"
+       gradientUnits="userSpaceOnUse"
+       y1="236.42"
+       x2="344.64999"
+       x1="364.35001">
+      <stop
+         id="stop4144"
+         style="stop-color:#88b637"
+         offset="0" />
+      <stop
+         id="stop4146"
+         style="stop-color:#88b637;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <filter
+       id="filter4300-5"
+       style="color-interpolation-filters:sRGB"
+       height="1.192"
+       width="1.192"
+       y="-0.096001998"
+       x="-0.095997997">
+      <feGaussianBlur
+         id="feGaussianBlur4302-3"
+         stdDeviation="16.623603" />
+    </filter>
+    <filter
+       id="filter4315-5"
+       style="color-interpolation-filters:sRGB"
+       height="1.024"
+       width="1.024"
+       y="-0.012"
+       x="-0.012">
+      <feGaussianBlur
+         id="feGaussianBlur4317-6"
+         stdDeviation="2.0779504" />
+    </filter>
+    <linearGradient
+       id="linearGradient4432-1"
+       y2="255.67"
+       gradientUnits="userSpaceOnUse"
+       y1="236.42"
+       x2="344.64999"
+       x1="364.35001">
+      <stop
+         id="stop4144-2"
+         style="stop-color:#88b637"
+         offset="0" />
+      <stop
+         id="stop4146-7"
+         style="stop-color:#88b637;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-361-6">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-29-2"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath936-4">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path938-4"
+         d="M 329.9375,16 C 475.2348,16 496,36.71323 496,181.875 v 116.25 C 496,443.28618 475.2348,464 329.9375,464 H 182.0625 C 36.7652,464 16,443.28618 16,298.125 V 181.875 C 16,36.71323 36.7652,16 182.0625,16 Z"
+         style="opacity:1;fill:#438ae9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8">
+      <stop
+         id="stop3750-1-0-7-6-6-1-3-9"
+         style="stop-color:#ffee55;stop-opacity:1"
+         offset="0" />
+      <stop
+         offset="0.42583728"
+         style="stop-color:#feeb46;stop-opacity:1"
+         id="stop1654" />
+      <stop
+         id="stop3752-3-7-4-0-32-8-923-0"
+         style="stop-color:#fc8f36;stop-opacity:1"
+         offset="0.50877196" />
+      <stop
+         offset="0.58839363"
+         style="stop-color:#ef6422;stop-opacity:1;"
+         id="stop1062" />
+      <stop
+         id="stop3754-1-8-5-2-7-6-7-1"
+         style="stop-color:#e23a0e;stop-opacity:1"
+         offset="0.6680153" />
+      <stop
+         offset="0.93725348"
+         style="stop-color:#b8017a;stop-opacity:0.97254902"
+         id="stop1658" />
+      <stop
+         id="stop3756-1-6-2-6-6-1-96-6"
+         style="stop-color:#b8017a;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.3011864,0.00583817,-0.0058295,0.30163426,118.4786,-1.6058194)"
+       id="4-6"
+       x1="-316.30048"
+       y1="93.99012"
+       x2="-308.03195"
+       y2="120.68974"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#ec3a00"
+         id="stop4650-2"
+         style="stop-color:#c00e62;stop-opacity:0.91588783" />
+      <stop
+         style="stop-color:#d63540;stop-opacity:0.95686275;"
+         id="stop957"
+         stop-color="#ec3a00"
+         offset="0.3302111" />
+      <stop
+         offset="1"
+         stop-color="#ffb900"
+         stop-opacity=".016"
+         id="stop4652-9"
+         style="stop-color:#7a5240;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.22977543,0.01949167,-0.02091519,0.21413666,101.18811,30.479268)"
+       id="5-5"
+       x1="-226.75"
+       x2="-170.39"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#de4000"
+         id="stop4645-3" />
+      <stop
+         offset="1"
+         stop-color="#fab600"
+         id="stop4647-5" />
+    </linearGradient>
+    <linearGradient
+       id="6-3"
+       x1="-258.12738"
+       y1="208.63644"
+       x2="-181.74777"
+       y2="298.31403"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.28446436,0,0,0.36122683,111.0341,-12.577201)">
+      <stop
+         stop-color="#f24d00"
+         id="stop4655-6"
+         style="stop-color:#961725;stop-opacity:1" />
+      <stop
+         style="stop-color:#f06824;stop-opacity:1"
+         id="stop963"
+         stop-color="#f24d00"
+         offset="0.19558652" />
+      <stop
+         id="stop3440"
+         stop-color="#f24d00"
+         offset="0.54072613"
+         style="stop-color:#f06723;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#ffb000"
+         id="stop4657-7" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="82.480003"
+       x2="-268.98999"
+       y1="120.49"
+       x1="-335.91"
+       id="linearGradient1050"
+       gradientTransform="matrix(0.29580808,0.0057254,-0.0057254,0.29580808,-23.568013,1.3300176)">
+      <stop
+         id="stop1046"
+         stop-color="#ec3a00"
+         style="stop-color:#fee246;stop-opacity:1" />
+      <stop
+         style="stop-color:#f59b00;stop-opacity:0.50588238"
+         stop-color="#ec3a00"
+         id="stop1060"
+         offset="0.69732404" />
+      <stop
+         id="stop1048"
+         stop-opacity=".016"
+         stop-color="#ffb900"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28406639,0.02406136,-0.02585699,0.26433945,-24.455783,13.444752)"
+       id="5-5-2"
+       x1="-226.75"
+       x2="-170.39"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#de4000"
+         id="stop4645-3-9" />
+      <stop
+         offset="1"
+         stop-color="#fab600"
+         id="stop4647-5-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1013"
+       id="linearGradient1108"
+       x1="296"
+       y1="-212"
+       x2="296"
+       y2="236"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient1013"
+       inkscape:collect="always">
+      <stop
+         id="stop1005"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.09803922"
+         offset="0.125"
+         id="stop1007" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.09803922"
+         offset="0.92500001"
+         id="stop1009" />
+      <stop
+         id="stop1011"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49803922" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3-367">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6-53"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath936">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path938"
+         d="M 329.9375,16 C 475.2348,16 496,36.71323 496,181.875 v 116.25 C 496,443.28618 475.2348,464 329.9375,464 H 182.0625 C 36.7652,464 16,443.28618 16,298.125 V 181.875 C 16,36.71323 36.7652,16 182.0625,16 Z"
+         style="opacity:1;fill:#438ae9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </clipPath>
+    <linearGradient
+       gradientTransform="matrix(2.0393079,0,0,2.0393079,-78.498127,-46.208135)"
+       inkscape:collect="always"
+       xlink:href="#radial-gradient-2"
+       id="linearGradient1048"
+       x1="267.04578"
+       y1="44.655418"
+       x2="-156.12532"
+       y2="300.65543"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter989"
+       x="-0.0232"
+       width="1.0464"
+       y="-0.024857143"
+       height="1.0497143">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.32"
+         id="feGaussianBlur991" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4569"
+       x="-0.0116"
+       width="1.0232"
+       y="-0.012428571"
+       height="1.024857">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.16"
+         id="feGaussianBlur4571" />
+    </filter>
+    <radialGradient
+       id="radial-gradient-2"
+       cx="-7529.6689"
+       cy="-7921.6079"
+       r="791.229"
+       gradientTransform="matrix(0.32411459,0,0,0.32411462,2358.4822,2727.5526)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#00ccda"
+         id="stop23" />
+      <stop
+         offset="0.22"
+         stop-color="#0083ff"
+         id="stop25" />
+      <stop
+         offset="0.261"
+         stop-color="#007af9"
+         id="stop27" />
+      <stop
+         offset="0.33"
+         stop-color="#0060e8"
+         id="stop29" />
+      <stop
+         offset="0.333"
+         stop-color="#005fe7"
+         id="stop31" />
+      <stop
+         offset="0.438"
+         stop-color="#2639ad"
+         id="stop33" />
+      <stop
+         offset="0.522"
+         stop-color="#401e84"
+         id="stop35" />
+      <stop
+         offset="0.566"
+         stop-color="#4a1475"
+         id="stop37" />
+    </radialGradient>
+    <radialGradient
+       id="m"
+       cx="178.60001"
+       cy="31.52"
+       gradientUnits="userSpaceOnUse"
+       r="216"
+       gradientTransform="matrix(1.3867599,0,0,1.38676,405.36903,-164.77434)">
+      <stop
+         offset=".082"
+         stop-color="#00a2dc"
+         id="stop91" />
+      <stop
+         offset=".161"
+         stop-color="#0096d4"
+         id="stop93" />
+      <stop
+         offset=".328"
+         stop-color="#2578b8"
+         id="stop95" />
+      <stop
+         offset=".33"
+         stop-color="#2276b8"
+         id="stop97" />
+      <stop
+         offset=".5"
+         stop-color="#035495"
+         id="stop99" />
+      <stop
+         offset=".832"
+         stop-color="#14143e"
+         id="stop101" />
+    </radialGradient>
+    <linearGradient
+       gradientTransform="matrix(0.22977543,0.01949167,-0.02091519,0.21413666,101.18811,30.479268)"
+       id="5-5-7"
+       x1="-226.75"
+       x2="-170.39"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#de4000"
+         id="stop4645-3-0" />
+      <stop
+         offset="1"
+         stop-color="#fab600"
+         id="stop4647-5-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28406639,0.02406136,-0.02585699,0.26433945,-24.455783,13.444752)"
+       id="5-5-2-8"
+       x1="-226.75"
+       x2="-170.39"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#de4000"
+         id="stop4645-3-9-7" />
+      <stop
+         offset="1"
+         stop-color="#fab600"
+         id="stop4647-5-1-9" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath936-2">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path938-0"
+         d="M 329.9375,16 C 475.2348,16 496,36.71323 496,181.875 l 0,116.25 C 496,443.28618 475.2348,464 329.9375,464 l -147.875,0 C 36.7652,464 16,443.28618 16,298.125 l 0,-116.25 C 16,36.71323 36.7652,16 182.0625,16 Z"
+         style="opacity:1;fill:#438ae9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </clipPath>
+    <linearGradient
+       id="b"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="68.25"
+       x2="52.689999"
+       y1="197.7"
+       y2="237.5">
+      <stop
+         offset=".011"
+         stop-color="#941f21"
+         id="stop12" />
+      <stop
+         offset=".472"
+         stop-color="#e36126"
+         id="stop14" />
+      <stop
+         offset="1"
+         stop-color="#f0bb62"
+         id="stop16" />
+    </linearGradient>
+    <linearGradient
+       id="c"
+       gradientTransform="matrix(0.9673,0.2537,0.2537,-0.9673,-1210,1129)"
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y1="1296"
+       y2="1133">
+      <stop
+         offset=".056"
+         stop-color="#dc7327"
+         id="stop19" />
+      <stop
+         offset="1"
+         stop-color="#eebc89"
+         id="stop21" />
+    </linearGradient>
+    <linearGradient
+       id="d"
+       gradientTransform="matrix(0.9897,-0.0801,-0.0949,-1.173,14.95,356.3)"
+       gradientUnits="userSpaceOnUse"
+       x1="42.540001"
+       x2="-12.4"
+       y1="211.60001"
+       y2="122.2">
+      <stop
+         offset=".056"
+         stop-color="#dc7327"
+         id="stop24" />
+      <stop
+         offset="1"
+         stop-color="#edbd6b"
+         id="stop26" />
+    </linearGradient>
+    <radialGradient
+       id="e"
+       cx="302.60001"
+       cy="260.39999"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="63.93">
+      <stop
+         offset=".257"
+         stop-color="#ffe300"
+         id="stop29-2" />
+      <stop
+         offset=".336"
+         stop-color="#fcd800"
+         id="stop31-9" />
+      <stop
+         offset=".47"
+         stop-color="#f8c91e"
+         id="stop33-1" />
+      <stop
+         offset=".643"
+         stop-color="#eda524"
+         id="stop35-2" />
+      <stop
+         offset=".847"
+         stop-color="#e37b28"
+         id="stop37-7" />
+      <stop
+         offset="1"
+         stop-color="#dd5a26"
+         id="stop39" />
+    </radialGradient>
+    <radialGradient
+       id="g"
+       cx="326.79999"
+       cy="211.10001"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="33.400002"
+       xlink:href="#f" />
+    <linearGradient
+       id="f">
+      <stop
+         offset=".126"
+         stop-color="#941f21"
+         id="stop42" />
+      <stop
+         offset=".343"
+         stop-color="#9e2922"
+         id="stop44" />
+      <stop
+         offset=".73"
+         stop-color="#c24028"
+         id="stop46" />
+      <stop
+         offset="1"
+         stop-color="#dc5726"
+         id="stop48" />
+    </linearGradient>
+    <radialGradient
+       id="h"
+       cx="284"
+       cy="-32.07"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="29.700001">
+      <stop
+         offset="0"
+         stop-color="#431413"
+         id="stop52" />
+      <stop
+         offset=".164"
+         stop-color="#631e1c"
+         id="stop54" />
+      <stop
+         offset=".332"
+         stop-color="#832320"
+         id="stop56" />
+      <stop
+         offset=".484"
+         stop-color="#9c2222"
+         id="stop58" />
+      <stop
+         offset=".615"
+         stop-color="#ac2023"
+         id="stop60" />
+      <stop
+         offset=".708"
+         stop-color="#b21f24"
+         id="stop62" />
+      <stop
+         offset=".999"
+         stop-color="#aa1f24"
+         id="stop64" />
+      <stop
+         offset="1"
+         stop-color="#a91f24"
+         id="stop66" />
+    </radialGradient>
+    <radialGradient
+       id="i"
+       cx="341.5"
+       cy="24.65"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="32.880001"
+       xlink:href="#f" />
+    <radialGradient
+       id="j"
+       cx="357.60001"
+       cy="121.2"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="29.700001"
+       xlink:href="#f" />
+    <radialGradient
+       id="k"
+       cx="348.79999"
+       cy="191.89999"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="37.110001">
+      <stop
+         offset="0"
+         stop-color="#941f21"
+         id="stop71" />
+      <stop
+         offset=".638"
+         stop-color="#c13f28"
+         id="stop73" />
+      <stop
+         offset="1"
+         stop-color="#dc5726"
+         id="stop75" />
+    </radialGradient>
+    <linearGradient
+       id="o"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="178"
+       x2="257.39999"
+       y1="119.4"
+       y2="10.52">
+      <stop
+         offset="0"
+         stop-color="#1d406f"
+         id="stop109" />
+      <stop
+         offset="1"
+         stop-color="#141728"
+         id="stop111" />
+    </linearGradient>
+    <radialGradient
+       id="p"
+       cx="279"
+       cy="216.89999"
+       gradientTransform="matrix(1,0,0,-0.9811,-22.54,278.8)"
+       gradientUnits="userSpaceOnUse"
+       r="322.20001">
+      <stop
+         offset=".119"
+         stop-color="#fff"
+         id="stop114" />
+      <stop
+         offset=".122"
+         stop-color="#fffffa"
+         id="stop116" />
+      <stop
+         offset=".25"
+         stop-color="#ffe560"
+         id="stop118" />
+      <stop
+         offset=".287"
+         stop-color="#ffdf56"
+         id="stop120" />
+      <stop
+         offset=".347"
+         stop-color="#f8d03b"
+         id="stop122" />
+      <stop
+         offset=".406"
+         stop-color="#f0be1b"
+         id="stop124" />
+      <stop
+         offset=".473"
+         stop-color="#eb9d23"
+         id="stop126" />
+      <stop
+         offset=".548"
+         stop-color="#e57c27"
+         id="stop128" />
+      <stop
+         offset=".765"
+         stop-color="#dd5626"
+         id="stop130" />
+      <stop
+         offset=".903"
+         stop-color="#c33a28"
+         id="stop132" />
+      <stop
+         offset="1"
+         stop-color="#b02228"
+         id="stop134" />
+    </radialGradient>
+    <radialGradient
+       id="q"
+       cx="224.5"
+       cy="165.89999"
+       gradientTransform="matrix(1,0,0,-0.9759,-22.54,277.9)"
+       gradientUnits="userSpaceOnUse"
+       r="239.5">
+      <stop
+         offset=".656"
+         stop-color="#b02228"
+         stop-opacity="0"
+         id="stop137" />
+      <stop
+         offset=".872"
+         stop-color="#b02127"
+         stop-opacity=".658"
+         id="stop139" />
+      <stop
+         offset=".973"
+         stop-color="#b21f24"
+         stop-opacity=".967"
+         id="stop141" />
+      <stop
+         offset=".984"
+         stop-color="#b21f24"
+         id="stop143" />
+    </radialGradient>
+    <radialGradient
+       id="r"
+       cx="246.7"
+       cy="84.769997"
+       gradientTransform="matrix(0.5289,-0.8327,-0.8392,-0.5131,164.8,444.5)"
+       gradientUnits="userSpaceOnUse"
+       r="244.60001">
+      <stop
+         offset=".71"
+         stop-color="#ed6624"
+         stop-opacity="0"
+         id="stop146" />
+      <stop
+         offset=".835"
+         stop-color="#ed6824"
+         stop-opacity=".489"
+         id="stop148" />
+      <stop
+         offset=".88"
+         stop-color="#ee6d24"
+         stop-opacity=".666"
+         id="stop150" />
+      <stop
+         offset=".912"
+         stop-color="#ef7624"
+         stop-opacity=".791"
+         id="stop152" />
+      <stop
+         offset=".938"
+         stop-color="#f28223"
+         stop-opacity=".893"
+         id="stop154" />
+      <stop
+         offset=".96"
+         stop-color="#f59123"
+         stop-opacity=".979"
+         id="stop156" />
+      <stop
+         offset=".966"
+         stop-color="#f69622"
+         id="stop158" />
+    </radialGradient>
+    <radialGradient
+       id="s"
+       cx="179.39999"
+       cy="84.110001"
+       gradientTransform="matrix(1,0,0,-0.6267,-22.54,146.1)"
+       gradientUnits="userSpaceOnUse"
+       r="78.669998">
+      <stop
+         offset="0"
+         stop-color="#e05a27"
+         stop-opacity=".1"
+         id="stop161" />
+      <stop
+         offset=".306"
+         stop-color="#de5926"
+         stop-opacity=".845"
+         id="stop163" />
+      <stop
+         offset=".556"
+         stop-color="#b02228"
+         id="stop165" />
+    </radialGradient>
+    <radialGradient
+       id="t"
+       cx="112"
+       cy="-77.959999"
+       gradientTransform="matrix(0.9539,-0.2859,-0.1382,-0.4185,33.31,94.9)"
+       gradientUnits="userSpaceOnUse"
+       r="66.230003">
+      <stop
+         offset="0"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop168" />
+      <stop
+         offset=".446"
+         stop-color="#dd5a26"
+         stop-opacity=".8"
+         id="stop170" />
+      <stop
+         offset=".722"
+         stop-color="#b02228"
+         id="stop172" />
+    </radialGradient>
+    <radialGradient
+       id="u"
+       cx="243.2"
+       cy="127.8"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="178.2">
+      <stop
+         offset=".463"
+         stop-color="#f0b91c"
+         id="stop175" />
+      <stop
+         offset=".722"
+         stop-color="#e36024"
+         id="stop177" />
+      <stop
+         offset=".782"
+         stop-color="#db5825"
+         id="stop179" />
+      <stop
+         offset=".876"
+         stop-color="#c74127"
+         id="stop181" />
+      <stop
+         offset=".97"
+         stop-color="#b02228"
+         id="stop183" />
+    </radialGradient>
+    <radialGradient
+       id="P"
+       cx="368.29999"
+       cy="228.7"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="215.60001">
+      <stop
+         offset=".306"
+         stop-color="#ffe300"
+         id="stop370" />
+      <stop
+         offset=".482"
+         stop-color="#f8c91e"
+         id="stop372" />
+      <stop
+         offset=".836"
+         stop-color="#e36024"
+         id="stop374" />
+      <stop
+         offset="1"
+         stop-color="#e36024"
+         id="stop376" />
+    </radialGradient>
+    <radialGradient
+       id="v"
+       cx="304.39999"
+       cy="146.7"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="87.660004">
+      <stop
+         offset=".09"
+         stop-color="#fff"
+         id="stop186" />
+      <stop
+         offset=".115"
+         stop-color="#fffef7"
+         id="stop188" />
+      <stop
+         offset=".151"
+         stop-color="#fffbe8"
+         id="stop190" />
+      <stop
+         offset=".193"
+         stop-color="#fff7d0"
+         id="stop192" />
+      <stop
+         offset=".239"
+         stop-color="#fff2af"
+         id="stop194" />
+      <stop
+         offset=".289"
+         stop-color="#ffec85"
+         id="stop196" />
+      <stop
+         offset=".342"
+         stop-color="#ffe643"
+         id="stop198" />
+      <stop
+         offset=".373"
+         stop-color="#ffe300"
+         id="stop200" />
+      <stop
+         offset=".418"
+         stop-color="#ffdb00"
+         id="stop202" />
+      <stop
+         offset=".494"
+         stop-color="#f6c713"
+         id="stop204" />
+      <stop
+         offset=".538"
+         stop-color="#f0b91c"
+         id="stop206" />
+      <stop
+         offset="1"
+         stop-color="#e36024"
+         id="stop208" />
+    </radialGradient>
+    <radialGradient
+       id="w"
+       cx="321.39999"
+       cy="157.3"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="159.10001">
+      <stop
+         offset=".09"
+         stop-color="#fff"
+         id="stop211" />
+      <stop
+         offset=".115"
+         stop-color="#fffef7"
+         id="stop213" />
+      <stop
+         offset=".151"
+         stop-color="#fffbe8"
+         id="stop215" />
+      <stop
+         offset=".193"
+         stop-color="#fff7d0"
+         id="stop217" />
+      <stop
+         offset=".239"
+         stop-color="#fff2af"
+         id="stop219" />
+      <stop
+         offset=".289"
+         stop-color="#ffec85"
+         id="stop221" />
+      <stop
+         offset=".342"
+         stop-color="#ffe643"
+         id="stop223" />
+      <stop
+         offset=".373"
+         stop-color="#ffe300"
+         id="stop225" />
+      <stop
+         offset=".418"
+         stop-color="#ffdb00"
+         id="stop227" />
+      <stop
+         offset=".494"
+         stop-color="#f6c713"
+         id="stop229" />
+      <stop
+         offset=".538"
+         stop-color="#f0b91c"
+         id="stop231" />
+      <stop
+         offset=".741"
+         stop-color="#e27327"
+         id="stop233" />
+      <stop
+         offset=".942"
+         stop-color="#dd5a26"
+         id="stop235" />
+    </radialGradient>
+    <radialGradient
+       id="Q"
+       cx="296.10001"
+       cy="115.8"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="134.7">
+      <stop
+         offset=".09"
+         stop-color="#fff"
+         id="stop379" />
+      <stop
+         offset=".106"
+         stop-color="#fffef7"
+         id="stop381" />
+      <stop
+         offset=".13"
+         stop-color="#fffbe8"
+         id="stop383" />
+      <stop
+         offset=".158"
+         stop-color="#fff7d0"
+         id="stop385" />
+      <stop
+         offset=".189"
+         stop-color="#fff2af"
+         id="stop387" />
+      <stop
+         offset=".222"
+         stop-color="#ffec85"
+         id="stop389" />
+      <stop
+         offset=".257"
+         stop-color="#ffe643"
+         id="stop391" />
+      <stop
+         offset=".277"
+         stop-color="#ffe300"
+         id="stop393" />
+      <stop
+         offset=".319"
+         stop-color="#ffdb00"
+         id="stop395" />
+      <stop
+         offset=".39"
+         stop-color="#f6c713"
+         id="stop397" />
+      <stop
+         offset=".43"
+         stop-color="#f0b91c"
+         id="stop399" />
+      <stop
+         offset=".505"
+         stop-color="#ea9e23"
+         id="stop401" />
+      <stop
+         offset=".632"
+         stop-color="#e27327"
+         id="stop403" />
+      <stop
+         offset=".801"
+         stop-color="#df6427"
+         id="stop405" />
+      <stop
+         offset=".948"
+         stop-color="#dd5a26"
+         id="stop407" />
+    </radialGradient>
+    <linearGradient
+       id="x"
+       gradientTransform="matrix(0.9995,-0.0314,-0.0314,-0.9995,-20.75,313)"
+       gradientUnits="userSpaceOnUse"
+       x1="254.8"
+       x2="232.10001"
+       y1="86.779999"
+       y2="-11.75">
+      <stop
+         offset="0"
+         stop-color="#fff038"
+         id="stop238" />
+      <stop
+         offset=".003"
+         stop-color="#ffec33"
+         id="stop240" />
+      <stop
+         offset=".051"
+         stop-color="#ffd92f"
+         id="stop242" />
+      <stop
+         offset=".136"
+         stop-color="#fcbc29"
+         id="stop244" />
+      <stop
+         offset=".214"
+         stop-color="#f9a725"
+         id="stop246" />
+      <stop
+         offset=".281"
+         stop-color="#f79b23"
+         id="stop248" />
+      <stop
+         offset=".33"
+         stop-color="#f69622"
+         id="stop250" />
+      <stop
+         offset=".82"
+         stop-color="#de5b26"
+         stop-opacity=".059"
+         id="stop252" />
+    </linearGradient>
+    <linearGradient
+       id="y"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="67.709999"
+       x2="47.57"
+       y1="195.8"
+       y2="247.39999">
+      <stop
+         offset=".169"
+         stop-color="#b02228"
+         id="stop255" />
+      <stop
+         offset=".406"
+         stop-color="#bf3628"
+         stop-opacity=".744"
+         id="stop257" />
+      <stop
+         offset=".623"
+         stop-color="#c84228"
+         stop-opacity=".51"
+         id="stop259" />
+      <stop
+         offset="1"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop261" />
+    </linearGradient>
+    <linearGradient
+       id="R"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="149.2"
+       x2="176"
+       y1="156.89999"
+       y2="168.8">
+      <stop
+         offset=".075"
+         stop-color="#dd5a26"
+         id="stop410" />
+      <stop
+         offset=".298"
+         stop-color="#e9986d"
+         id="stop412" />
+      <stop
+         offset=".667"
+         stop-color="#f4d4ac"
+         id="stop414" />
+      <stop
+         offset="1"
+         stop-color="#f9f7c9"
+         id="stop416" />
+    </linearGradient>
+    <linearGradient
+       id="S"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="151.60001"
+       x2="220.89999"
+       y1="153.89999"
+       y2="188.7">
+      <stop
+         offset=".044"
+         stop-color="#dd5a26"
+         id="stop419" />
+      <stop
+         offset=".258"
+         stop-color="#eca77c"
+         id="stop421" />
+      <stop
+         offset="1"
+         stop-color="#f9f7c9"
+         id="stop423" />
+    </linearGradient>
+    <radialGradient
+       id="z"
+       cx="175"
+       cy="30.26"
+       gradientTransform="matrix(1,0,0,-0.8428,-22.54,246)"
+       gradientUnits="userSpaceOnUse"
+       r="95.220001">
+      <stop
+         offset=".5"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop264" />
+      <stop
+         offset=".75"
+         stop-color="#de5926"
+         stop-opacity=".775"
+         id="stop266" />
+      <stop
+         offset=".95"
+         stop-color="#b02228"
+         id="stop268" />
+    </radialGradient>
+    <linearGradient
+       id="A"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="177.7"
+       x2="197.89999"
+       y1="169.3"
+       y2="200.39999">
+      <stop
+         offset="0"
+         stop-color="#37383a"
+         id="stop271" />
+      <stop
+         offset=".651"
+         stop-color="#7b3f3d"
+         id="stop273" />
+      <stop
+         offset="1"
+         stop-color="#dd5a26"
+         id="stop275" />
+    </linearGradient>
+    <radialGradient
+       id="B"
+       cx="127.8"
+       cy="34.34"
+       gradientTransform="matrix(0.9863,-0.1647,-0.1249,-0.7478,15.64,224.4)"
+       gradientUnits="userSpaceOnUse"
+       r="87.309998">
+      <stop
+         offset=".5"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop278" />
+      <stop
+         offset=".656"
+         stop-color="#dd5a26"
+         id="stop280" />
+      <stop
+         offset=".815"
+         stop-color="#b02228"
+         id="stop282" />
+    </radialGradient>
+    <radialGradient
+       id="C"
+       cx="263.39999"
+       cy="264.29999"
+       gradientTransform="matrix(0.9996,-0.0268,-0.0263,-0.9807,-11.59,293.6)"
+       gradientUnits="userSpaceOnUse"
+       r="164.5">
+      <stop
+         offset="0"
+         stop-color="#ffe000"
+         stop-opacity="0"
+         id="stop285" />
+      <stop
+         offset=".355"
+         stop-color="#fed700"
+         stop-opacity=".515"
+         id="stop287" />
+      <stop
+         offset=".483"
+         stop-color="#fed208"
+         stop-opacity=".7"
+         id="stop289" />
+      <stop
+         offset=".857"
+         stop-color="#fed208"
+         stop-opacity="0"
+         id="stop291" />
+    </radialGradient>
+    <radialGradient
+       id="E"
+       cx="126.4"
+       cy="63.740002"
+       gradientUnits="userSpaceOnUse"
+       r="210.7"
+       xlink:href="#D" />
+    <linearGradient
+       id="D">
+      <stop
+         offset="0"
+         stop-color="#ed6624"
+         id="stop294" />
+      <stop
+         offset="1"
+         stop-color="#f69622"
+         id="stop296" />
+    </linearGradient>
+    <radialGradient
+       id="G"
+       cx="-1402"
+       cy="-1212"
+       gradientTransform="matrix(-0.2756,0.9504,-0.6431,-0.1776,-962.9,1319)"
+       gradientUnits="userSpaceOnUse"
+       r="53.880001"
+       xlink:href="#F" />
+    <linearGradient
+       id="F">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         id="stop300" />
+      <stop
+         offset=".027"
+         stop-color="#fffbe8"
+         stop-opacity=".963"
+         id="stop302" />
+      <stop
+         offset=".102"
+         stop-color="#fff2b6"
+         stop-opacity=".857"
+         id="stop304" />
+      <stop
+         offset=".174"
+         stop-color="#ffed8c"
+         stop-opacity=".756"
+         id="stop306" />
+      <stop
+         offset=".24"
+         stop-color="#ffe967"
+         stop-opacity=".662"
+         id="stop308" />
+      <stop
+         offset=".3"
+         stop-color="#ffe645"
+         stop-opacity=".578"
+         id="stop310" />
+      <stop
+         offset=".352"
+         stop-color="#ffe42c"
+         stop-opacity=".506"
+         id="stop312" />
+      <stop
+         offset=".389"
+         stop-color="#ffe421"
+         stop-opacity=".454"
+         id="stop314" />
+      <stop
+         offset=".809"
+         stop-color="#ffe300"
+         stop-opacity="0"
+         id="stop316" />
+    </linearGradient>
+    <radialGradient
+       id="H"
+       cx="-1472"
+       cy="-1159"
+       gradientTransform="matrix(-0.3166,0.8278,-0.6529,-0.2379,-1017,1150)"
+       gradientUnits="userSpaceOnUse"
+       r="56.150002"
+       xlink:href="#F" />
+    <radialGradient
+       id="I"
+       cx="-1629"
+       cy="-1332"
+       gradientTransform="matrix(-0.2345,0.5201,-0.5377,-0.2307,-894.6,746.3)"
+       gradientUnits="userSpaceOnUse"
+       r="42.110001"
+       xlink:href="#F" />
+    <linearGradient
+       id="J"
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y1="155.7"
+       y2="346.60001">
+      <stop
+         offset="0"
+         stop-color="#e57c27"
+         id="stop322" />
+      <stop
+         offset=".5"
+         stop-color="#dd5626"
+         id="stop324" />
+      <stop
+         offset=".647"
+         stop-color="#c33a28"
+         id="stop326" />
+      <stop
+         offset=".75"
+         stop-color="#b02228"
+         id="stop328" />
+      <stop
+         offset=".813"
+         stop-color="#ab2026"
+         id="stop330" />
+      <stop
+         offset=".913"
+         stop-color="#9c1c21"
+         id="stop332" />
+      <stop
+         offset="1"
+         stop-color="#8c161a"
+         id="stop334" />
+    </linearGradient>
+    <radialGradient
+       id="K"
+       cx="2913"
+       cy="-4629"
+       gradientTransform="matrix(0.0279,-0.9996,0.9996,0.0279,4654,3343)"
+       gradientUnits="userSpaceOnUse"
+       r="111.6"
+       xlink:href="#D" />
+    <radialGradient
+       id="L"
+       cx="75.470001"
+       cy="84.059998"
+       gradientTransform="matrix(0.9569,0.2903,-0.1939,0.6392,19.55,8.419)"
+       gradientUnits="userSpaceOnUse"
+       r="43.93">
+      <stop
+         offset=".487"
+         stop-color="#e57c27"
+         stop-opacity="0"
+         id="stop338" />
+      <stop
+         offset=".853"
+         stop-color="#f0be1b"
+         id="stop340" />
+    </radialGradient>
+    <linearGradient
+       id="b-0"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="68.25"
+       x2="52.689999"
+       y1="197.7"
+       y2="237.5">
+      <stop
+         offset=".011"
+         stop-color="#941f21"
+         id="stop12-9" />
+      <stop
+         offset=".472"
+         stop-color="#e36126"
+         id="stop14-3" />
+      <stop
+         offset="1"
+         stop-color="#f0bb62"
+         id="stop16-6" />
+    </linearGradient>
+    <linearGradient
+       id="c-0"
+       gradientTransform="matrix(0.9673,0.2537,0.2537,-0.9673,-1210,1129)"
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y1="1296"
+       y2="1133">
+      <stop
+         offset=".056"
+         stop-color="#dc7327"
+         id="stop19-6" />
+      <stop
+         offset="1"
+         stop-color="#eebc89"
+         id="stop21-2" />
+    </linearGradient>
+    <linearGradient
+       id="d-6"
+       gradientTransform="matrix(0.9897,-0.0801,-0.0949,-1.173,14.95,356.3)"
+       gradientUnits="userSpaceOnUse"
+       x1="42.540001"
+       x2="-12.4"
+       y1="211.60001"
+       y2="122.2">
+      <stop
+         offset=".056"
+         stop-color="#dc7327"
+         id="stop24-1" />
+      <stop
+         offset="1"
+         stop-color="#edbd6b"
+         id="stop26-8" />
+    </linearGradient>
+    <radialGradient
+       id="e-7"
+       cx="302.60001"
+       cy="260.39999"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="63.93">
+      <stop
+         offset=".257"
+         stop-color="#ffe300"
+         id="stop29-2-9" />
+      <stop
+         offset=".336"
+         stop-color="#fcd800"
+         id="stop31-9-2" />
+      <stop
+         offset=".47"
+         stop-color="#f8c91e"
+         id="stop33-1-0" />
+      <stop
+         offset=".643"
+         stop-color="#eda524"
+         id="stop35-2-2" />
+      <stop
+         offset=".847"
+         stop-color="#e37b28"
+         id="stop37-7-3" />
+      <stop
+         offset="1"
+         stop-color="#dd5a26"
+         id="stop39-7" />
+    </radialGradient>
+    <radialGradient
+       id="g-5"
+       cx="326.79999"
+       cy="211.10001"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="33.400002"
+       xlink:href="#f" />
+    <radialGradient
+       id="h-9"
+       cx="284"
+       cy="-32.07"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="29.700001">
+      <stop
+         offset="0"
+         stop-color="#431413"
+         id="stop52-7" />
+      <stop
+         offset=".164"
+         stop-color="#631e1c"
+         id="stop54-3" />
+      <stop
+         offset=".332"
+         stop-color="#832320"
+         id="stop56-6" />
+      <stop
+         offset=".484"
+         stop-color="#9c2222"
+         id="stop58-1" />
+      <stop
+         offset=".615"
+         stop-color="#ac2023"
+         id="stop60-2" />
+      <stop
+         offset=".708"
+         stop-color="#b21f24"
+         id="stop62-9" />
+      <stop
+         offset=".999"
+         stop-color="#aa1f24"
+         id="stop64-3" />
+      <stop
+         offset="1"
+         stop-color="#a91f24"
+         id="stop66-1" />
+    </radialGradient>
+    <radialGradient
+       id="i-9"
+       cx="341.5"
+       cy="24.65"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="32.880001"
+       xlink:href="#f" />
+    <radialGradient
+       id="j-4"
+       cx="357.60001"
+       cy="121.2"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="29.700001"
+       xlink:href="#f" />
+    <radialGradient
+       id="k-7"
+       cx="348.79999"
+       cy="191.89999"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="37.110001">
+      <stop
+         offset="0"
+         stop-color="#941f21"
+         id="stop71-8" />
+      <stop
+         offset=".638"
+         stop-color="#c13f28"
+         id="stop73-4" />
+      <stop
+         offset="1"
+         stop-color="#dc5726"
+         id="stop75-5" />
+    </radialGradient>
+    <linearGradient
+       id="o-0"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="178"
+       x2="257.39999"
+       y1="119.4"
+       y2="10.52">
+      <stop
+         offset="0"
+         stop-color="#1d406f"
+         id="stop109-3" />
+      <stop
+         offset="1"
+         stop-color="#141728"
+         id="stop111-6" />
+    </linearGradient>
+    <radialGradient
+       id="p-1"
+       cx="279"
+       cy="216.89999"
+       gradientTransform="matrix(1,0,0,-0.9811,-22.54,278.8)"
+       gradientUnits="userSpaceOnUse"
+       r="322.20001">
+      <stop
+         offset=".119"
+         stop-color="#fff"
+         id="stop114-0" />
+      <stop
+         offset=".122"
+         stop-color="#fffffa"
+         id="stop116-6" />
+      <stop
+         offset=".25"
+         stop-color="#ffe560"
+         id="stop118-3" />
+      <stop
+         offset=".287"
+         stop-color="#ffdf56"
+         id="stop120-2" />
+      <stop
+         offset=".347"
+         stop-color="#f8d03b"
+         id="stop122-0" />
+      <stop
+         offset=".406"
+         stop-color="#f0be1b"
+         id="stop124-6" />
+      <stop
+         offset=".473"
+         stop-color="#eb9d23"
+         id="stop126-1" />
+      <stop
+         offset=".548"
+         stop-color="#e57c27"
+         id="stop128-5" />
+      <stop
+         offset=".765"
+         stop-color="#dd5626"
+         id="stop130-5" />
+      <stop
+         offset=".903"
+         stop-color="#c33a28"
+         id="stop132-4" />
+      <stop
+         offset="1"
+         stop-color="#b02228"
+         id="stop134-7" />
+    </radialGradient>
+    <radialGradient
+       id="q-6"
+       cx="224.5"
+       cy="165.89999"
+       gradientTransform="matrix(1,0,0,-0.9759,-22.54,277.9)"
+       gradientUnits="userSpaceOnUse"
+       r="239.5">
+      <stop
+         offset=".656"
+         stop-color="#b02228"
+         stop-opacity="0"
+         id="stop137-5" />
+      <stop
+         offset=".872"
+         stop-color="#b02127"
+         stop-opacity=".658"
+         id="stop139-6" />
+      <stop
+         offset=".973"
+         stop-color="#b21f24"
+         stop-opacity=".967"
+         id="stop141-9" />
+      <stop
+         offset=".984"
+         stop-color="#b21f24"
+         id="stop143-3" />
+    </radialGradient>
+    <radialGradient
+       id="r-7"
+       cx="246.7"
+       cy="84.769997"
+       gradientTransform="matrix(0.5289,-0.8327,-0.8392,-0.5131,164.8,444.5)"
+       gradientUnits="userSpaceOnUse"
+       r="244.60001">
+      <stop
+         offset=".71"
+         stop-color="#ed6624"
+         stop-opacity="0"
+         id="stop146-4" />
+      <stop
+         offset=".835"
+         stop-color="#ed6824"
+         stop-opacity=".489"
+         id="stop148-5" />
+      <stop
+         offset=".88"
+         stop-color="#ee6d24"
+         stop-opacity=".666"
+         id="stop150-2" />
+      <stop
+         offset=".912"
+         stop-color="#ef7624"
+         stop-opacity=".791"
+         id="stop152-5" />
+      <stop
+         offset=".938"
+         stop-color="#f28223"
+         stop-opacity=".893"
+         id="stop154-4" />
+      <stop
+         offset=".96"
+         stop-color="#f59123"
+         stop-opacity=".979"
+         id="stop156-7" />
+      <stop
+         offset=".966"
+         stop-color="#f69622"
+         id="stop158-4" />
+    </radialGradient>
+    <radialGradient
+       id="s-4"
+       cx="179.39999"
+       cy="84.110001"
+       gradientTransform="matrix(1,0,0,-0.6267,-22.54,146.1)"
+       gradientUnits="userSpaceOnUse"
+       r="78.669998">
+      <stop
+         offset="0"
+         stop-color="#e05a27"
+         stop-opacity=".1"
+         id="stop161-3" />
+      <stop
+         offset=".306"
+         stop-color="#de5926"
+         stop-opacity=".845"
+         id="stop163-0" />
+      <stop
+         offset=".556"
+         stop-color="#b02228"
+         id="stop165-7" />
+    </radialGradient>
+    <radialGradient
+       id="t-8"
+       cx="112"
+       cy="-77.959999"
+       gradientTransform="matrix(0.9539,-0.2859,-0.1382,-0.4185,33.31,94.9)"
+       gradientUnits="userSpaceOnUse"
+       r="66.230003">
+      <stop
+         offset="0"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop168-6" />
+      <stop
+         offset=".446"
+         stop-color="#dd5a26"
+         stop-opacity=".8"
+         id="stop170-8" />
+      <stop
+         offset=".722"
+         stop-color="#b02228"
+         id="stop172-8" />
+    </radialGradient>
+    <radialGradient
+       id="u-4"
+       cx="243.2"
+       cy="127.8"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="178.2">
+      <stop
+         offset=".463"
+         stop-color="#f0b91c"
+         id="stop175-3" />
+      <stop
+         offset=".722"
+         stop-color="#e36024"
+         id="stop177-1" />
+      <stop
+         offset=".782"
+         stop-color="#db5825"
+         id="stop179-4" />
+      <stop
+         offset=".876"
+         stop-color="#c74127"
+         id="stop181-9" />
+      <stop
+         offset=".97"
+         stop-color="#b02228"
+         id="stop183-2" />
+    </radialGradient>
+    <radialGradient
+       id="P-0"
+       cx="368.29999"
+       cy="228.7"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="215.60001">
+      <stop
+         offset=".306"
+         stop-color="#ffe300"
+         id="stop370-6" />
+      <stop
+         offset=".482"
+         stop-color="#f8c91e"
+         id="stop372-8" />
+      <stop
+         offset=".836"
+         stop-color="#e36024"
+         id="stop374-9" />
+      <stop
+         offset="1"
+         stop-color="#e36024"
+         id="stop376-2" />
+    </radialGradient>
+    <radialGradient
+       id="v-6"
+       cx="304.39999"
+       cy="146.7"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="87.660004">
+      <stop
+         offset=".09"
+         stop-color="#fff"
+         id="stop186-6" />
+      <stop
+         offset=".115"
+         stop-color="#fffef7"
+         id="stop188-4" />
+      <stop
+         offset=".151"
+         stop-color="#fffbe8"
+         id="stop190-9" />
+      <stop
+         offset=".193"
+         stop-color="#fff7d0"
+         id="stop192-5" />
+      <stop
+         offset=".239"
+         stop-color="#fff2af"
+         id="stop194-0" />
+      <stop
+         offset=".289"
+         stop-color="#ffec85"
+         id="stop196-4" />
+      <stop
+         offset=".342"
+         stop-color="#ffe643"
+         id="stop198-8" />
+      <stop
+         offset=".373"
+         stop-color="#ffe300"
+         id="stop200-7" />
+      <stop
+         offset=".418"
+         stop-color="#ffdb00"
+         id="stop202-1" />
+      <stop
+         offset=".494"
+         stop-color="#f6c713"
+         id="stop204-7" />
+      <stop
+         offset=".538"
+         stop-color="#f0b91c"
+         id="stop206-2" />
+      <stop
+         offset="1"
+         stop-color="#e36024"
+         id="stop208-7" />
+    </radialGradient>
+    <radialGradient
+       id="w-2"
+       cx="321.39999"
+       cy="157.3"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="159.10001">
+      <stop
+         offset=".09"
+         stop-color="#fff"
+         id="stop211-2" />
+      <stop
+         offset=".115"
+         stop-color="#fffef7"
+         id="stop213-6" />
+      <stop
+         offset=".151"
+         stop-color="#fffbe8"
+         id="stop215-1" />
+      <stop
+         offset=".193"
+         stop-color="#fff7d0"
+         id="stop217-0" />
+      <stop
+         offset=".239"
+         stop-color="#fff2af"
+         id="stop219-6" />
+      <stop
+         offset=".289"
+         stop-color="#ffec85"
+         id="stop221-1" />
+      <stop
+         offset=".342"
+         stop-color="#ffe643"
+         id="stop223-5" />
+      <stop
+         offset=".373"
+         stop-color="#ffe300"
+         id="stop225-9" />
+      <stop
+         offset=".418"
+         stop-color="#ffdb00"
+         id="stop227-4" />
+      <stop
+         offset=".494"
+         stop-color="#f6c713"
+         id="stop229-9" />
+      <stop
+         offset=".538"
+         stop-color="#f0b91c"
+         id="stop231-0" />
+      <stop
+         offset=".741"
+         stop-color="#e27327"
+         id="stop233-9" />
+      <stop
+         offset=".942"
+         stop-color="#dd5a26"
+         id="stop235-1" />
+    </radialGradient>
+    <radialGradient
+       id="Q-7"
+       cx="296.10001"
+       cy="115.8"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="134.7">
+      <stop
+         offset=".09"
+         stop-color="#fff"
+         id="stop379-7" />
+      <stop
+         offset=".106"
+         stop-color="#fffef7"
+         id="stop381-1" />
+      <stop
+         offset=".13"
+         stop-color="#fffbe8"
+         id="stop383-1" />
+      <stop
+         offset=".158"
+         stop-color="#fff7d0"
+         id="stop385-5" />
+      <stop
+         offset=".189"
+         stop-color="#fff2af"
+         id="stop387-9" />
+      <stop
+         offset=".222"
+         stop-color="#ffec85"
+         id="stop389-7" />
+      <stop
+         offset=".257"
+         stop-color="#ffe643"
+         id="stop391-7" />
+      <stop
+         offset=".277"
+         stop-color="#ffe300"
+         id="stop393-6" />
+      <stop
+         offset=".319"
+         stop-color="#ffdb00"
+         id="stop395-7" />
+      <stop
+         offset=".39"
+         stop-color="#f6c713"
+         id="stop397-3" />
+      <stop
+         offset=".43"
+         stop-color="#f0b91c"
+         id="stop399-6" />
+      <stop
+         offset=".505"
+         stop-color="#ea9e23"
+         id="stop401-5" />
+      <stop
+         offset=".632"
+         stop-color="#e27327"
+         id="stop403-6" />
+      <stop
+         offset=".801"
+         stop-color="#df6427"
+         id="stop405-3" />
+      <stop
+         offset=".948"
+         stop-color="#dd5a26"
+         id="stop407-9" />
+    </radialGradient>
+    <linearGradient
+       id="x-4"
+       gradientTransform="matrix(0.9995,-0.0314,-0.0314,-0.9995,-20.75,313)"
+       gradientUnits="userSpaceOnUse"
+       x1="254.8"
+       x2="232.10001"
+       y1="86.779999"
+       y2="-11.75">
+      <stop
+         offset="0"
+         stop-color="#fff038"
+         id="stop238-8" />
+      <stop
+         offset=".003"
+         stop-color="#ffec33"
+         id="stop240-1" />
+      <stop
+         offset=".051"
+         stop-color="#ffd92f"
+         id="stop242-2" />
+      <stop
+         offset=".136"
+         stop-color="#fcbc29"
+         id="stop244-9" />
+      <stop
+         offset=".214"
+         stop-color="#f9a725"
+         id="stop246-3" />
+      <stop
+         offset=".281"
+         stop-color="#f79b23"
+         id="stop248-9" />
+      <stop
+         offset=".33"
+         stop-color="#f69622"
+         id="stop250-0" />
+      <stop
+         offset=".82"
+         stop-color="#de5b26"
+         stop-opacity=".059"
+         id="stop252-8" />
+    </linearGradient>
+    <linearGradient
+       id="y-8"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="67.709999"
+       x2="47.57"
+       y1="195.8"
+       y2="247.39999">
+      <stop
+         offset=".169"
+         stop-color="#b02228"
+         id="stop255-5" />
+      <stop
+         offset=".406"
+         stop-color="#bf3628"
+         stop-opacity=".744"
+         id="stop257-0" />
+      <stop
+         offset=".623"
+         stop-color="#c84228"
+         stop-opacity=".51"
+         id="stop259-9" />
+      <stop
+         offset="1"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop261-6" />
+    </linearGradient>
+    <linearGradient
+       id="R-3"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="149.2"
+       x2="176"
+       y1="156.89999"
+       y2="168.8">
+      <stop
+         offset=".075"
+         stop-color="#dd5a26"
+         id="stop410-8" />
+      <stop
+         offset=".298"
+         stop-color="#e9986d"
+         id="stop412-5" />
+      <stop
+         offset=".667"
+         stop-color="#f4d4ac"
+         id="stop414-6" />
+      <stop
+         offset="1"
+         stop-color="#f9f7c9"
+         id="stop416-1" />
+    </linearGradient>
+    <linearGradient
+       id="S-1"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="151.60001"
+       x2="220.89999"
+       y1="153.89999"
+       y2="188.7">
+      <stop
+         offset=".044"
+         stop-color="#dd5a26"
+         id="stop419-5" />
+      <stop
+         offset=".258"
+         stop-color="#eca77c"
+         id="stop421-9" />
+      <stop
+         offset="1"
+         stop-color="#f9f7c9"
+         id="stop423-8" />
+    </linearGradient>
+    <radialGradient
+       id="z-4"
+       cx="175"
+       cy="30.26"
+       gradientTransform="matrix(1,0,0,-0.8428,-22.54,246)"
+       gradientUnits="userSpaceOnUse"
+       r="95.220001">
+      <stop
+         offset=".5"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop264-8" />
+      <stop
+         offset=".75"
+         stop-color="#de5926"
+         stop-opacity=".775"
+         id="stop266-1" />
+      <stop
+         offset=".95"
+         stop-color="#b02228"
+         id="stop268-0" />
+    </radialGradient>
+    <linearGradient
+       id="A-3"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="177.7"
+       x2="197.89999"
+       y1="169.3"
+       y2="200.39999">
+      <stop
+         offset="0"
+         stop-color="#37383a"
+         id="stop271-0" />
+      <stop
+         offset=".651"
+         stop-color="#7b3f3d"
+         id="stop273-4" />
+      <stop
+         offset="1"
+         stop-color="#dd5a26"
+         id="stop275-4" />
+    </linearGradient>
+    <radialGradient
+       id="B-4"
+       cx="127.8"
+       cy="34.34"
+       gradientTransform="matrix(0.9863,-0.1647,-0.1249,-0.7478,15.64,224.4)"
+       gradientUnits="userSpaceOnUse"
+       r="87.309998">
+      <stop
+         offset=".5"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop278-4" />
+      <stop
+         offset=".656"
+         stop-color="#dd5a26"
+         id="stop280-7" />
+      <stop
+         offset=".815"
+         stop-color="#b02228"
+         id="stop282-6" />
+    </radialGradient>
+    <radialGradient
+       id="C-3"
+       cx="263.39999"
+       cy="264.29999"
+       gradientTransform="matrix(0.9996,-0.0268,-0.0263,-0.9807,-11.59,293.6)"
+       gradientUnits="userSpaceOnUse"
+       r="164.5">
+      <stop
+         offset="0"
+         stop-color="#ffe000"
+         stop-opacity="0"
+         id="stop285-1" />
+      <stop
+         offset=".355"
+         stop-color="#fed700"
+         stop-opacity=".515"
+         id="stop287-7" />
+      <stop
+         offset=".483"
+         stop-color="#fed208"
+         stop-opacity=".7"
+         id="stop289-5" />
+      <stop
+         offset=".857"
+         stop-color="#fed208"
+         stop-opacity="0"
+         id="stop291-9" />
+    </radialGradient>
+    <radialGradient
+       id="E-6"
+       cx="126.4"
+       cy="63.740002"
+       gradientUnits="userSpaceOnUse"
+       r="210.7"
+       xlink:href="#D" />
+    <radialGradient
+       id="G-7"
+       cx="-1402"
+       cy="-1212"
+       gradientTransform="matrix(-0.2756,0.9504,-0.6431,-0.1776,-962.9,1319)"
+       gradientUnits="userSpaceOnUse"
+       r="53.880001"
+       xlink:href="#F" />
+    <radialGradient
+       id="H-5"
+       cx="-1472"
+       cy="-1159"
+       gradientTransform="matrix(-0.3166,0.8278,-0.6529,-0.2379,-1017,1150)"
+       gradientUnits="userSpaceOnUse"
+       r="56.150002"
+       xlink:href="#F" />
+    <radialGradient
+       id="I-3"
+       cx="-1629"
+       cy="-1332"
+       gradientTransform="matrix(-0.2345,0.5201,-0.5377,-0.2307,-894.6,746.3)"
+       gradientUnits="userSpaceOnUse"
+       r="42.110001"
+       xlink:href="#F" />
+    <linearGradient
+       id="J-8"
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y1="155.7"
+       y2="346.60001">
+      <stop
+         offset="0"
+         stop-color="#e57c27"
+         id="stop322-8" />
+      <stop
+         offset=".5"
+         stop-color="#dd5626"
+         id="stop324-3" />
+      <stop
+         offset=".647"
+         stop-color="#c33a28"
+         id="stop326-1" />
+      <stop
+         offset=".75"
+         stop-color="#b02228"
+         id="stop328-8" />
+      <stop
+         offset=".813"
+         stop-color="#ab2026"
+         id="stop330-9" />
+      <stop
+         offset=".913"
+         stop-color="#9c1c21"
+         id="stop332-6" />
+      <stop
+         offset="1"
+         stop-color="#8c161a"
+         id="stop334-4" />
+    </linearGradient>
+    <radialGradient
+       id="K-3"
+       cx="2913"
+       cy="-4629"
+       gradientTransform="matrix(0.0279,-0.9996,0.9996,0.0279,4654,3343)"
+       gradientUnits="userSpaceOnUse"
+       r="111.6"
+       xlink:href="#D" />
+    <radialGradient
+       id="L-3"
+       cx="75.470001"
+       cy="84.059998"
+       gradientTransform="matrix(0.9569,0.2903,-0.1939,0.6392,19.55,8.419)"
+       gradientUnits="userSpaceOnUse"
+       r="43.93">
+      <stop
+         offset=".487"
+         stop-color="#e57c27"
+         stop-opacity="0"
+         id="stop338-3" />
+      <stop
+         offset=".853"
+         stop-color="#f0be1b"
+         id="stop340-8" />
+    </radialGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5684"
+       x="-0.011453752"
+       width="1.0229075"
+       y="-0.01260096"
+       height="1.0252019">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.6814247"
+         id="feGaussianBlur5686" />
+    </filter>
+    <linearGradient
+       id="b-9"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="68.25"
+       x2="52.689999"
+       y1="197.7"
+       y2="237.5">
+      <stop
+         offset=".011"
+         stop-color="#941f21"
+         id="stop12-3" />
+      <stop
+         offset=".472"
+         stop-color="#e36126"
+         id="stop14-6" />
+      <stop
+         offset="1"
+         stop-color="#f0bb62"
+         id="stop16-8" />
+    </linearGradient>
+    <linearGradient
+       id="c-02"
+       gradientTransform="matrix(0.9673,0.2537,0.2537,-0.9673,-1210,1129)"
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y1="1296"
+       y2="1133">
+      <stop
+         offset=".056"
+         stop-color="#dc7327"
+         id="stop19-1" />
+      <stop
+         offset="1"
+         stop-color="#eebc89"
+         id="stop21-0" />
+    </linearGradient>
+    <linearGradient
+       id="d-5"
+       gradientTransform="matrix(0.9897,-0.0801,-0.0949,-1.173,14.95,356.3)"
+       gradientUnits="userSpaceOnUse"
+       x1="42.540001"
+       x2="-12.4"
+       y1="211.60001"
+       y2="122.2">
+      <stop
+         offset=".056"
+         stop-color="#dc7327"
+         id="stop24-11" />
+      <stop
+         offset="1"
+         stop-color="#edbd6b"
+         id="stop26-0" />
+    </linearGradient>
+    <radialGradient
+       id="e-8"
+       cx="302.60001"
+       cy="260.39999"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="63.93">
+      <stop
+         offset=".257"
+         stop-color="#ffe300"
+         id="stop29-2-5" />
+      <stop
+         offset=".336"
+         stop-color="#fcd800"
+         id="stop31-9-0" />
+      <stop
+         offset=".47"
+         stop-color="#f8c91e"
+         id="stop33-1-6" />
+      <stop
+         offset=".643"
+         stop-color="#eda524"
+         id="stop35-2-4" />
+      <stop
+         offset=".847"
+         stop-color="#e37b28"
+         id="stop37-7-6" />
+      <stop
+         offset="1"
+         stop-color="#dd5a26"
+         id="stop39-2" />
+    </radialGradient>
+    <radialGradient
+       id="g-58"
+       cx="326.79999"
+       cy="211.10001"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="33.400002"
+       xlink:href="#f" />
+    <radialGradient
+       id="h-7"
+       cx="284"
+       cy="-32.07"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="29.700001">
+      <stop
+         offset="0"
+         stop-color="#431413"
+         id="stop52-2" />
+      <stop
+         offset=".164"
+         stop-color="#631e1c"
+         id="stop54-4" />
+      <stop
+         offset=".332"
+         stop-color="#832320"
+         id="stop56-0" />
+      <stop
+         offset=".484"
+         stop-color="#9c2222"
+         id="stop58-6" />
+      <stop
+         offset=".615"
+         stop-color="#ac2023"
+         id="stop60-29" />
+      <stop
+         offset=".708"
+         stop-color="#b21f24"
+         id="stop62-90" />
+      <stop
+         offset=".999"
+         stop-color="#aa1f24"
+         id="stop64-8" />
+      <stop
+         offset="1"
+         stop-color="#a91f24"
+         id="stop66-13" />
+    </radialGradient>
+    <radialGradient
+       id="i-1"
+       cx="341.5"
+       cy="24.65"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="32.880001"
+       xlink:href="#f" />
+    <radialGradient
+       id="j-1"
+       cx="357.60001"
+       cy="121.2"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="29.700001"
+       xlink:href="#f" />
+    <radialGradient
+       id="k-0"
+       cx="348.79999"
+       cy="191.89999"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="37.110001">
+      <stop
+         offset="0"
+         stop-color="#941f21"
+         id="stop71-3" />
+      <stop
+         offset=".638"
+         stop-color="#c13f28"
+         id="stop73-40" />
+      <stop
+         offset="1"
+         stop-color="#dc5726"
+         id="stop75-3" />
+    </radialGradient>
+    <linearGradient
+       id="o-9"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="178"
+       x2="257.39999"
+       y1="119.4"
+       y2="10.52">
+      <stop
+         offset="0"
+         stop-color="#1d406f"
+         id="stop109-1" />
+      <stop
+         offset="1"
+         stop-color="#141728"
+         id="stop111-9" />
+    </linearGradient>
+    <radialGradient
+       id="p-6"
+       cx="279"
+       cy="216.89999"
+       gradientTransform="matrix(1,0,0,-0.9811,-22.54,278.8)"
+       gradientUnits="userSpaceOnUse"
+       r="322.20001">
+      <stop
+         offset=".119"
+         stop-color="#fff"
+         id="stop114-9" />
+      <stop
+         offset=".122"
+         stop-color="#fffffa"
+         id="stop116-3" />
+      <stop
+         offset=".25"
+         stop-color="#ffe560"
+         id="stop118-38" />
+      <stop
+         offset=".287"
+         stop-color="#ffdf56"
+         id="stop120-0" />
+      <stop
+         offset=".347"
+         stop-color="#f8d03b"
+         id="stop122-5" />
+      <stop
+         offset=".406"
+         stop-color="#f0be1b"
+         id="stop124-66" />
+      <stop
+         offset=".473"
+         stop-color="#eb9d23"
+         id="stop126-4" />
+      <stop
+         offset=".548"
+         stop-color="#e57c27"
+         id="stop128-0" />
+      <stop
+         offset=".765"
+         stop-color="#dd5626"
+         id="stop130-0" />
+      <stop
+         offset=".903"
+         stop-color="#c33a28"
+         id="stop132-46" />
+      <stop
+         offset="1"
+         stop-color="#b02228"
+         id="stop134-2" />
+    </radialGradient>
+    <radialGradient
+       id="q-67"
+       cx="224.5"
+       cy="165.89999"
+       gradientTransform="matrix(1,0,0,-0.9759,-22.54,277.9)"
+       gradientUnits="userSpaceOnUse"
+       r="239.5">
+      <stop
+         offset=".656"
+         stop-color="#b02228"
+         stop-opacity="0"
+         id="stop137-56" />
+      <stop
+         offset=".872"
+         stop-color="#b02127"
+         stop-opacity=".658"
+         id="stop139-9" />
+      <stop
+         offset=".973"
+         stop-color="#b21f24"
+         stop-opacity=".967"
+         id="stop141-8" />
+      <stop
+         offset=".984"
+         stop-color="#b21f24"
+         id="stop143-7" />
+    </radialGradient>
+    <radialGradient
+       id="r-2"
+       cx="246.7"
+       cy="84.769997"
+       gradientTransform="matrix(0.5289,-0.8327,-0.8392,-0.5131,164.8,444.5)"
+       gradientUnits="userSpaceOnUse"
+       r="244.60001">
+      <stop
+         offset=".71"
+         stop-color="#ed6624"
+         stop-opacity="0"
+         id="stop146-8" />
+      <stop
+         offset=".835"
+         stop-color="#ed6824"
+         stop-opacity=".489"
+         id="stop148-2" />
+      <stop
+         offset=".88"
+         stop-color="#ee6d24"
+         stop-opacity=".666"
+         id="stop150-9" />
+      <stop
+         offset=".912"
+         stop-color="#ef7624"
+         stop-opacity=".791"
+         id="stop152-9" />
+      <stop
+         offset=".938"
+         stop-color="#f28223"
+         stop-opacity=".893"
+         id="stop154-6" />
+      <stop
+         offset=".96"
+         stop-color="#f59123"
+         stop-opacity=".979"
+         id="stop156-0" />
+      <stop
+         offset=".966"
+         stop-color="#f69622"
+         id="stop158-2" />
+    </radialGradient>
+    <radialGradient
+       id="s-7"
+       cx="179.39999"
+       cy="84.110001"
+       gradientTransform="matrix(1,0,0,-0.6267,-22.54,146.1)"
+       gradientUnits="userSpaceOnUse"
+       r="78.669998">
+      <stop
+         offset="0"
+         stop-color="#e05a27"
+         stop-opacity=".1"
+         id="stop161-6" />
+      <stop
+         offset=".306"
+         stop-color="#de5926"
+         stop-opacity=".845"
+         id="stop163-1" />
+      <stop
+         offset=".556"
+         stop-color="#b02228"
+         id="stop165-3" />
+    </radialGradient>
+    <radialGradient
+       id="t-2"
+       cx="112"
+       cy="-77.959999"
+       gradientTransform="matrix(0.9539,-0.2859,-0.1382,-0.4185,33.31,94.9)"
+       gradientUnits="userSpaceOnUse"
+       r="66.230003">
+      <stop
+         offset="0"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop168-1" />
+      <stop
+         offset=".446"
+         stop-color="#dd5a26"
+         stop-opacity=".8"
+         id="stop170-5" />
+      <stop
+         offset=".722"
+         stop-color="#b02228"
+         id="stop172-9" />
+    </radialGradient>
+    <radialGradient
+       id="u-9"
+       cx="243.2"
+       cy="127.8"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="178.2">
+      <stop
+         offset=".463"
+         stop-color="#f0b91c"
+         id="stop175-1" />
+      <stop
+         offset=".722"
+         stop-color="#e36024"
+         id="stop177-4" />
+      <stop
+         offset=".782"
+         stop-color="#db5825"
+         id="stop179-9" />
+      <stop
+         offset=".876"
+         stop-color="#c74127"
+         id="stop181-1" />
+      <stop
+         offset=".97"
+         stop-color="#b02228"
+         id="stop183-0" />
+    </radialGradient>
+    <radialGradient
+       id="P-7"
+       cx="368.29999"
+       cy="228.7"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="215.60001">
+      <stop
+         offset=".306"
+         stop-color="#ffe300"
+         id="stop370-5" />
+      <stop
+         offset=".482"
+         stop-color="#f8c91e"
+         id="stop372-87" />
+      <stop
+         offset=".836"
+         stop-color="#e36024"
+         id="stop374-0" />
+      <stop
+         offset="1"
+         stop-color="#e36024"
+         id="stop376-4" />
+    </radialGradient>
+    <radialGradient
+       id="v-8"
+       cx="304.39999"
+       cy="146.7"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="87.660004">
+      <stop
+         offset=".09"
+         stop-color="#fff"
+         id="stop186-0" />
+      <stop
+         offset=".115"
+         stop-color="#fffef7"
+         id="stop188-42" />
+      <stop
+         offset=".151"
+         stop-color="#fffbe8"
+         id="stop190-96" />
+      <stop
+         offset=".193"
+         stop-color="#fff7d0"
+         id="stop192-1" />
+      <stop
+         offset=".239"
+         stop-color="#fff2af"
+         id="stop194-04" />
+      <stop
+         offset=".289"
+         stop-color="#ffec85"
+         id="stop196-2" />
+      <stop
+         offset=".342"
+         stop-color="#ffe643"
+         id="stop198-2" />
+      <stop
+         offset=".373"
+         stop-color="#ffe300"
+         id="stop200-2" />
+      <stop
+         offset=".418"
+         stop-color="#ffdb00"
+         id="stop202-0" />
+      <stop
+         offset=".494"
+         stop-color="#f6c713"
+         id="stop204-5" />
+      <stop
+         offset=".538"
+         stop-color="#f0b91c"
+         id="stop206-5" />
+      <stop
+         offset="1"
+         stop-color="#e36024"
+         id="stop208-2" />
+    </radialGradient>
+    <radialGradient
+       id="w-9"
+       cx="321.39999"
+       cy="157.3"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="159.10001">
+      <stop
+         offset=".09"
+         stop-color="#fff"
+         id="stop211-0" />
+      <stop
+         offset=".115"
+         stop-color="#fffef7"
+         id="stop213-2" />
+      <stop
+         offset=".151"
+         stop-color="#fffbe8"
+         id="stop215-8" />
+      <stop
+         offset=".193"
+         stop-color="#fff7d0"
+         id="stop217-3" />
+      <stop
+         offset=".239"
+         stop-color="#fff2af"
+         id="stop219-8" />
+      <stop
+         offset=".289"
+         stop-color="#ffec85"
+         id="stop221-0" />
+      <stop
+         offset=".342"
+         stop-color="#ffe643"
+         id="stop223-4" />
+      <stop
+         offset=".373"
+         stop-color="#ffe300"
+         id="stop225-0" />
+      <stop
+         offset=".418"
+         stop-color="#ffdb00"
+         id="stop227-9" />
+      <stop
+         offset=".494"
+         stop-color="#f6c713"
+         id="stop229-1" />
+      <stop
+         offset=".538"
+         stop-color="#f0b91c"
+         id="stop231-9" />
+      <stop
+         offset=".741"
+         stop-color="#e27327"
+         id="stop233-6" />
+      <stop
+         offset=".942"
+         stop-color="#dd5a26"
+         id="stop235-2" />
+    </radialGradient>
+    <radialGradient
+       id="Q-5"
+       cx="296.10001"
+       cy="115.8"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="134.7">
+      <stop
+         offset=".09"
+         stop-color="#fff"
+         id="stop379-4" />
+      <stop
+         offset=".106"
+         stop-color="#fffef7"
+         id="stop381-4" />
+      <stop
+         offset=".13"
+         stop-color="#fffbe8"
+         id="stop383-9" />
+      <stop
+         offset=".158"
+         stop-color="#fff7d0"
+         id="stop385-9" />
+      <stop
+         offset=".189"
+         stop-color="#fff2af"
+         id="stop387-3" />
+      <stop
+         offset=".222"
+         stop-color="#ffec85"
+         id="stop389-6" />
+      <stop
+         offset=".257"
+         stop-color="#ffe643"
+         id="stop391-0" />
+      <stop
+         offset=".277"
+         stop-color="#ffe300"
+         id="stop393-5" />
+      <stop
+         offset=".319"
+         stop-color="#ffdb00"
+         id="stop395-0" />
+      <stop
+         offset=".39"
+         stop-color="#f6c713"
+         id="stop397-2" />
+      <stop
+         offset=".43"
+         stop-color="#f0b91c"
+         id="stop399-9" />
+      <stop
+         offset=".505"
+         stop-color="#ea9e23"
+         id="stop401-4" />
+      <stop
+         offset=".632"
+         stop-color="#e27327"
+         id="stop403-3" />
+      <stop
+         offset=".801"
+         stop-color="#df6427"
+         id="stop405-5" />
+      <stop
+         offset=".948"
+         stop-color="#dd5a26"
+         id="stop407-1" />
+    </radialGradient>
+    <linearGradient
+       id="x-7"
+       gradientTransform="matrix(0.9995,-0.0314,-0.0314,-0.9995,-20.75,313)"
+       gradientUnits="userSpaceOnUse"
+       x1="254.8"
+       x2="232.10001"
+       y1="86.779999"
+       y2="-11.75">
+      <stop
+         offset="0"
+         stop-color="#fff038"
+         id="stop238-4" />
+      <stop
+         offset=".003"
+         stop-color="#ffec33"
+         id="stop240-3" />
+      <stop
+         offset=".051"
+         stop-color="#ffd92f"
+         id="stop242-1" />
+      <stop
+         offset=".136"
+         stop-color="#fcbc29"
+         id="stop244-4" />
+      <stop
+         offset=".214"
+         stop-color="#f9a725"
+         id="stop246-6" />
+      <stop
+         offset=".281"
+         stop-color="#f79b23"
+         id="stop248-94" />
+      <stop
+         offset=".33"
+         stop-color="#f69622"
+         id="stop250-2" />
+      <stop
+         offset=".82"
+         stop-color="#de5b26"
+         stop-opacity=".059"
+         id="stop252-2" />
+    </linearGradient>
+    <linearGradient
+       id="y-6"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="67.709999"
+       x2="47.57"
+       y1="195.8"
+       y2="247.39999">
+      <stop
+         offset=".169"
+         stop-color="#b02228"
+         id="stop255-4" />
+      <stop
+         offset=".406"
+         stop-color="#bf3628"
+         stop-opacity=".744"
+         id="stop257-1" />
+      <stop
+         offset=".623"
+         stop-color="#c84228"
+         stop-opacity=".51"
+         id="stop259-2" />
+      <stop
+         offset="1"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop261-8" />
+    </linearGradient>
+    <linearGradient
+       id="R-8"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="149.2"
+       x2="176"
+       y1="156.89999"
+       y2="168.8">
+      <stop
+         offset=".075"
+         stop-color="#dd5a26"
+         id="stop410-9" />
+      <stop
+         offset=".298"
+         stop-color="#e9986d"
+         id="stop412-2" />
+      <stop
+         offset=".667"
+         stop-color="#f4d4ac"
+         id="stop414-8" />
+      <stop
+         offset="1"
+         stop-color="#f9f7c9"
+         id="stop416-8" />
+    </linearGradient>
+    <linearGradient
+       id="S-8"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="151.60001"
+       x2="220.89999"
+       y1="153.89999"
+       y2="188.7">
+      <stop
+         offset=".044"
+         stop-color="#dd5a26"
+         id="stop419-6" />
+      <stop
+         offset=".258"
+         stop-color="#eca77c"
+         id="stop421-8" />
+      <stop
+         offset="1"
+         stop-color="#f9f7c9"
+         id="stop423-3" />
+    </linearGradient>
+    <radialGradient
+       id="z-8"
+       cx="175"
+       cy="30.26"
+       gradientTransform="matrix(1,0,0,-0.8428,-22.54,246)"
+       gradientUnits="userSpaceOnUse"
+       r="95.220001">
+      <stop
+         offset=".5"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop264-3" />
+      <stop
+         offset=".75"
+         stop-color="#de5926"
+         stop-opacity=".775"
+         id="stop266-3" />
+      <stop
+         offset=".95"
+         stop-color="#b02228"
+         id="stop268-3" />
+    </radialGradient>
+    <linearGradient
+       id="A-8"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       x1="177.7"
+       x2="197.89999"
+       y1="169.3"
+       y2="200.39999">
+      <stop
+         offset="0"
+         stop-color="#37383a"
+         id="stop271-04" />
+      <stop
+         offset=".651"
+         stop-color="#7b3f3d"
+         id="stop273-7" />
+      <stop
+         offset="1"
+         stop-color="#dd5a26"
+         id="stop275-6" />
+    </linearGradient>
+    <radialGradient
+       id="B-8"
+       cx="127.8"
+       cy="34.34"
+       gradientTransform="matrix(0.9863,-0.1647,-0.1249,-0.7478,15.64,224.4)"
+       gradientUnits="userSpaceOnUse"
+       r="87.309998">
+      <stop
+         offset=".5"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop278-9" />
+      <stop
+         offset=".656"
+         stop-color="#dd5a26"
+         id="stop280-0" />
+      <stop
+         offset=".815"
+         stop-color="#b02228"
+         id="stop282-68" />
+    </radialGradient>
+    <radialGradient
+       id="C-7"
+       cx="263.39999"
+       cy="264.29999"
+       gradientTransform="matrix(0.9996,-0.0268,-0.0263,-0.9807,-11.59,293.6)"
+       gradientUnits="userSpaceOnUse"
+       r="164.5">
+      <stop
+         offset="0"
+         stop-color="#ffe000"
+         stop-opacity="0"
+         id="stop285-9" />
+      <stop
+         offset=".355"
+         stop-color="#fed700"
+         stop-opacity=".515"
+         id="stop287-0" />
+      <stop
+         offset=".483"
+         stop-color="#fed208"
+         stop-opacity=".7"
+         id="stop289-3" />
+      <stop
+         offset=".857"
+         stop-color="#fed208"
+         stop-opacity="0"
+         id="stop291-3" />
+    </radialGradient>
+    <radialGradient
+       id="E-3"
+       cx="126.4"
+       cy="63.740002"
+       gradientUnits="userSpaceOnUse"
+       r="210.7"
+       xlink:href="#D" />
+    <radialGradient
+       id="G-2"
+       cx="-1402"
+       cy="-1212"
+       gradientTransform="matrix(-0.2756,0.9504,-0.6431,-0.1776,-962.9,1319)"
+       gradientUnits="userSpaceOnUse"
+       r="53.880001"
+       xlink:href="#F" />
+    <radialGradient
+       id="H-0"
+       cx="-1472"
+       cy="-1159"
+       gradientTransform="matrix(-0.3166,0.8278,-0.6529,-0.2379,-1017,1150)"
+       gradientUnits="userSpaceOnUse"
+       r="56.150002"
+       xlink:href="#F" />
+    <radialGradient
+       id="I-4"
+       cx="-1629"
+       cy="-1332"
+       gradientTransform="matrix(-0.2345,0.5201,-0.5377,-0.2307,-894.6,746.3)"
+       gradientUnits="userSpaceOnUse"
+       r="42.110001"
+       xlink:href="#F" />
+    <linearGradient
+       id="J-1"
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y1="155.7"
+       y2="346.60001">
+      <stop
+         offset="0"
+         stop-color="#e57c27"
+         id="stop322-0" />
+      <stop
+         offset=".5"
+         stop-color="#dd5626"
+         id="stop324-4" />
+      <stop
+         offset=".647"
+         stop-color="#c33a28"
+         id="stop326-8" />
+      <stop
+         offset=".75"
+         stop-color="#b02228"
+         id="stop328-7" />
+      <stop
+         offset=".813"
+         stop-color="#ab2026"
+         id="stop330-0" />
+      <stop
+         offset=".913"
+         stop-color="#9c1c21"
+         id="stop332-8" />
+      <stop
+         offset="1"
+         stop-color="#8c161a"
+         id="stop334-6" />
+    </linearGradient>
+    <radialGradient
+       id="K-2"
+       cx="2913"
+       cy="-4629"
+       gradientTransform="matrix(0.0279,-0.9996,0.9996,0.0279,4654,3343)"
+       gradientUnits="userSpaceOnUse"
+       r="111.6"
+       xlink:href="#D" />
+    <radialGradient
+       id="L-4"
+       cx="75.470001"
+       cy="84.059998"
+       gradientTransform="matrix(0.9569,0.2903,-0.1939,0.6392,19.55,8.419)"
+       gradientUnits="userSpaceOnUse"
+       r="43.93">
+      <stop
+         offset=".487"
+         stop-color="#e57c27"
+         stop-opacity="0"
+         id="stop338-7" />
+      <stop
+         offset=".853"
+         stop-color="#f0be1b"
+         id="stop340-9" />
+    </radialGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter6644"
+       x="-0.11453752"
+       width="1.229075"
+       y="-0.1260096"
+       height="1.2520192">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="16.814247"
+         id="feGaussianBlur6646" />
+    </filter>
+    <linearGradient
+       id="c-3"
+       gradientTransform="matrix(0.9673,0.2537,0.2537,-0.9673,-1210,1129)"
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y1="1296"
+       y2="1133">
+      <stop
+         offset=".056"
+         stop-color="#dc7327"
+         id="stop19-5" />
+      <stop
+         offset="1"
+         stop-color="#eebc89"
+         id="stop21-6" />
+    </linearGradient>
+    <radialGradient
+       id="e-2"
+       cx="302.60001"
+       cy="260.39999"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="63.93">
+      <stop
+         offset=".257"
+         stop-color="#ffe300"
+         id="stop29-7" />
+      <stop
+         offset=".336"
+         stop-color="#fcd800"
+         id="stop31-0" />
+      <stop
+         offset=".47"
+         stop-color="#f8c91e"
+         id="stop33-9" />
+      <stop
+         offset=".643"
+         stop-color="#eda524"
+         id="stop35-3" />
+      <stop
+         offset=".847"
+         stop-color="#e37b28"
+         id="stop37-6" />
+      <stop
+         offset="1"
+         stop-color="#dd5a26"
+         id="stop39-0" />
+    </radialGradient>
+    <radialGradient
+       id="g-6"
+       cx="326.79999"
+       cy="211.10001"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="33.400002"
+       xlink:href="#f" />
+    <radialGradient
+       id="h-79"
+       cx="284"
+       cy="-32.07"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="29.700001">
+      <stop
+         offset="0"
+         stop-color="#431413"
+         id="stop52-20" />
+      <stop
+         offset=".164"
+         stop-color="#631e1c"
+         id="stop54-2" />
+      <stop
+         offset=".332"
+         stop-color="#832320"
+         id="stop56-3" />
+      <stop
+         offset=".484"
+         stop-color="#9c2222"
+         id="stop58-7" />
+      <stop
+         offset=".615"
+         stop-color="#ac2023"
+         id="stop60-5" />
+      <stop
+         offset=".708"
+         stop-color="#b21f24"
+         id="stop62-92" />
+      <stop
+         offset=".999"
+         stop-color="#aa1f24"
+         id="stop64-2" />
+      <stop
+         offset="1"
+         stop-color="#a91f24"
+         id="stop66-8" />
+    </radialGradient>
+    <radialGradient
+       id="i-97"
+       cx="341.5"
+       cy="24.65"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="32.880001"
+       xlink:href="#f" />
+    <radialGradient
+       id="j-3"
+       cx="357.60001"
+       cy="121.2"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="29.700001"
+       xlink:href="#f" />
+    <radialGradient
+       id="k-6"
+       cx="348.79999"
+       cy="191.89999"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="37.110001">
+      <stop
+         offset="0"
+         stop-color="#941f21"
+         id="stop71-1" />
+      <stop
+         offset=".638"
+         stop-color="#c13f28"
+         id="stop73-2" />
+      <stop
+         offset="1"
+         stop-color="#dc5726"
+         id="stop75-9" />
+    </radialGradient>
+    <radialGradient
+       id="p-7"
+       cx="279"
+       cy="216.89999"
+       gradientTransform="matrix(1,0,0,-0.9811,-22.54,278.8)"
+       gradientUnits="userSpaceOnUse"
+       r="322.20001">
+      <stop
+         offset=".119"
+         stop-color="#fff"
+         id="stop114-8" />
+      <stop
+         offset=".122"
+         stop-color="#fffffa"
+         id="stop116-4" />
+      <stop
+         offset=".25"
+         stop-color="#ffe560"
+         id="stop118-5" />
+      <stop
+         offset=".287"
+         stop-color="#ffdf56"
+         id="stop120-03" />
+      <stop
+         offset=".347"
+         stop-color="#f8d03b"
+         id="stop122-6" />
+      <stop
+         offset=".406"
+         stop-color="#f0be1b"
+         id="stop124-1" />
+      <stop
+         offset=".473"
+         stop-color="#eb9d23"
+         id="stop126-0" />
+      <stop
+         offset=".548"
+         stop-color="#e57c27"
+         id="stop128-6" />
+      <stop
+         offset=".765"
+         stop-color="#dd5626"
+         id="stop130-3" />
+      <stop
+         offset=".903"
+         stop-color="#c33a28"
+         id="stop132-2" />
+      <stop
+         offset="1"
+         stop-color="#b02228"
+         id="stop134-0" />
+    </radialGradient>
+    <radialGradient
+       id="q-61"
+       cx="224.5"
+       cy="165.89999"
+       gradientTransform="matrix(1,0,0,-0.9759,-22.54,277.9)"
+       gradientUnits="userSpaceOnUse"
+       r="239.5">
+      <stop
+         offset=".656"
+         stop-color="#b02228"
+         stop-opacity="0"
+         id="stop137-55" />
+      <stop
+         offset=".872"
+         stop-color="#b02127"
+         stop-opacity=".658"
+         id="stop139-4" />
+      <stop
+         offset=".973"
+         stop-color="#b21f24"
+         stop-opacity=".967"
+         id="stop141-7" />
+      <stop
+         offset=".984"
+         stop-color="#b21f24"
+         id="stop143-6" />
+    </radialGradient>
+    <radialGradient
+       id="r-5"
+       cx="246.7"
+       cy="84.769997"
+       gradientTransform="matrix(0.51094506,-0.80443175,-0.81071109,-0.49568144,171.15379,441.06272)"
+       gradientUnits="userSpaceOnUse"
+       r="244.60001">
+      <stop
+         offset=".71"
+         stop-color="#ed6624"
+         stop-opacity="0"
+         id="stop146-6" />
+      <stop
+         offset=".835"
+         stop-color="#ed6824"
+         stop-opacity=".489"
+         id="stop148-9" />
+      <stop
+         offset=".88"
+         stop-color="#ee6d24"
+         stop-opacity=".666"
+         id="stop150-3" />
+      <stop
+         offset=".912"
+         stop-color="#ef7624"
+         stop-opacity=".791"
+         id="stop152-7" />
+      <stop
+         offset=".938"
+         stop-color="#f28223"
+         stop-opacity=".893"
+         id="stop154-45" />
+      <stop
+         offset=".96"
+         stop-color="#f59123"
+         stop-opacity=".979"
+         id="stop156-2" />
+      <stop
+         offset=".966"
+         stop-color="#f69622"
+         id="stop158-5" />
+    </radialGradient>
+    <radialGradient
+       id="s-47"
+       cx="179.39999"
+       cy="84.110001"
+       gradientTransform="matrix(1,0,0,-0.6267,-22.54,146.1)"
+       gradientUnits="userSpaceOnUse"
+       r="78.669998">
+      <stop
+         offset="0"
+         stop-color="#e05a27"
+         stop-opacity=".1"
+         id="stop161-4" />
+      <stop
+         offset=".306"
+         stop-color="#de5926"
+         stop-opacity=".845"
+         id="stop163-4" />
+      <stop
+         offset=".556"
+         stop-color="#b02228"
+         id="stop165-30" />
+    </radialGradient>
+    <radialGradient
+       id="t-7"
+       cx="112"
+       cy="-77.959999"
+       gradientTransform="matrix(0.9539,-0.2859,-0.1382,-0.4185,33.31,94.9)"
+       gradientUnits="userSpaceOnUse"
+       r="66.230003">
+      <stop
+         offset="0"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop168-8" />
+      <stop
+         offset=".446"
+         stop-color="#dd5a26"
+         stop-opacity=".8"
+         id="stop170-6" />
+      <stop
+         offset=".722"
+         stop-color="#b02228"
+         id="stop172-88" />
+    </radialGradient>
+    <radialGradient
+       id="u-43"
+       cx="243.2"
+       cy="127.8"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="178.2">
+      <stop
+         offset=".463"
+         stop-color="#f0b91c"
+         id="stop175-14" />
+      <stop
+         offset=".722"
+         stop-color="#e36024"
+         id="stop177-9" />
+      <stop
+         offset=".782"
+         stop-color="#db5825"
+         id="stop179-2" />
+      <stop
+         offset=".876"
+         stop-color="#c74127"
+         id="stop181-0" />
+      <stop
+         offset=".97"
+         stop-color="#b02228"
+         id="stop183-6" />
+    </radialGradient>
+    <radialGradient
+       id="P-8"
+       cx="368.29999"
+       cy="228.7"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="215.60001">
+      <stop
+         offset=".306"
+         stop-color="#ffe300"
+         id="stop370-9" />
+      <stop
+         offset=".482"
+         stop-color="#f8c91e"
+         id="stop372-2" />
+      <stop
+         offset=".836"
+         stop-color="#e36024"
+         id="stop374-6" />
+      <stop
+         offset="1"
+         stop-color="#e36024"
+         id="stop376-6" />
+    </radialGradient>
+    <radialGradient
+       id="v-4"
+       cx="304.39999"
+       cy="146.7"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="87.660004">
+      <stop
+         offset=".09"
+         stop-color="#fff"
+         id="stop186-9" />
+      <stop
+         offset=".115"
+         stop-color="#fffef7"
+         id="stop188-5" />
+      <stop
+         offset=".151"
+         stop-color="#fffbe8"
+         id="stop190-0" />
+      <stop
+         offset=".193"
+         stop-color="#fff7d0"
+         id="stop192-4" />
+      <stop
+         offset=".239"
+         stop-color="#fff2af"
+         id="stop194-8" />
+      <stop
+         offset=".289"
+         stop-color="#ffec85"
+         id="stop196-7" />
+      <stop
+         offset=".342"
+         stop-color="#ffe643"
+         id="stop198-1" />
+      <stop
+         offset=".373"
+         stop-color="#ffe300"
+         id="stop200-72" />
+      <stop
+         offset=".418"
+         stop-color="#ffdb00"
+         id="stop202-7" />
+      <stop
+         offset=".494"
+         stop-color="#f6c713"
+         id="stop204-2" />
+      <stop
+         offset=".538"
+         stop-color="#f0b91c"
+         id="stop206-26" />
+      <stop
+         offset="1"
+         stop-color="#e36024"
+         id="stop208-1" />
+    </radialGradient>
+    <radialGradient
+       id="w-0"
+       cx="321.39999"
+       cy="157.3"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="159.10001">
+      <stop
+         offset=".09"
+         stop-color="#fff"
+         id="stop211-6" />
+      <stop
+         offset=".115"
+         stop-color="#fffef7"
+         id="stop213-1" />
+      <stop
+         offset=".151"
+         stop-color="#fffbe8"
+         id="stop215-5" />
+      <stop
+         offset=".193"
+         stop-color="#fff7d0"
+         id="stop217-9" />
+      <stop
+         offset=".239"
+         stop-color="#fff2af"
+         id="stop219-4" />
+      <stop
+         offset=".289"
+         stop-color="#ffec85"
+         id="stop221-9" />
+      <stop
+         offset=".342"
+         stop-color="#ffe643"
+         id="stop223-0" />
+      <stop
+         offset=".373"
+         stop-color="#ffe300"
+         id="stop225-91" />
+      <stop
+         offset=".418"
+         stop-color="#ffdb00"
+         id="stop227-7" />
+      <stop
+         offset=".494"
+         stop-color="#f6c713"
+         id="stop229-7" />
+      <stop
+         offset=".538"
+         stop-color="#f0b91c"
+         id="stop231-1" />
+      <stop
+         offset=".741"
+         stop-color="#e27327"
+         id="stop233-1" />
+      <stop
+         offset=".942"
+         stop-color="#dd5a26"
+         id="stop235-5" />
+    </radialGradient>
+    <radialGradient
+       id="Q-9"
+       cx="296.10001"
+       cy="115.8"
+       gradientTransform="matrix(1,0,0,-1,-22.54,286.4)"
+       gradientUnits="userSpaceOnUse"
+       r="134.7">
+      <stop
+         offset=".09"
+         stop-color="#fff"
+         id="stop379-77" />
+      <stop
+         offset=".106"
+         stop-color="#fffef7"
+         id="stop381-6" />
+      <stop
+         offset=".13"
+         stop-color="#fffbe8"
+         id="stop383-7" />
+      <stop
+         offset=".158"
+         stop-color="#fff7d0"
+         id="stop385-3" />
+      <stop
+         offset=".189"
+         stop-color="#fff2af"
+         id="stop387-6" />
+      <stop
+         offset=".222"
+         stop-color="#ffec85"
+         id="stop389-5" />
+      <stop
+         offset=".257"
+         stop-color="#ffe643"
+         id="stop391-6" />
+      <stop
+         offset=".277"
+         stop-color="#ffe300"
+         id="stop393-3" />
+      <stop
+         offset=".319"
+         stop-color="#ffdb00"
+         id="stop395-9" />
+      <stop
+         offset=".39"
+         stop-color="#f6c713"
+         id="stop397-4" />
+      <stop
+         offset=".43"
+         stop-color="#f0b91c"
+         id="stop399-8" />
+      <stop
+         offset=".505"
+         stop-color="#ea9e23"
+         id="stop401-1" />
+      <stop
+         offset=".632"
+         stop-color="#e27327"
+         id="stop403-2" />
+      <stop
+         offset=".801"
+         stop-color="#df6427"
+         id="stop405-9" />
+      <stop
+         offset=".948"
+         stop-color="#dd5a26"
+         id="stop407-3" />
+    </radialGradient>
+    <radialGradient
+       id="z-6"
+       cx="175"
+       cy="30.26"
+       gradientTransform="matrix(1,0,0,-0.8428,-22.54,246)"
+       gradientUnits="userSpaceOnUse"
+       r="95.220001">
+      <stop
+         offset=".5"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop264-31" />
+      <stop
+         offset=".75"
+         stop-color="#de5926"
+         stop-opacity=".775"
+         id="stop266-7" />
+      <stop
+         offset=".95"
+         stop-color="#b02228"
+         id="stop268-5" />
+    </radialGradient>
+    <radialGradient
+       id="B-7"
+       cx="127.8"
+       cy="34.34"
+       gradientTransform="matrix(0.9863,-0.1647,-0.1249,-0.7478,15.64,224.4)"
+       gradientUnits="userSpaceOnUse"
+       r="87.309998">
+      <stop
+         offset=".5"
+         stop-color="#e05a27"
+         stop-opacity="0"
+         id="stop278-8" />
+      <stop
+         offset=".656"
+         stop-color="#dd5a26"
+         id="stop280-5" />
+      <stop
+         offset=".815"
+         stop-color="#b02228"
+         id="stop282-7" />
+    </radialGradient>
+    <radialGradient
+       id="C-4"
+       cx="263.39999"
+       cy="264.29999"
+       gradientTransform="matrix(0.9996,-0.0268,-0.0263,-0.9807,-11.59,293.6)"
+       gradientUnits="userSpaceOnUse"
+       r="164.5">
+      <stop
+         offset="0"
+         stop-color="#ffe000"
+         stop-opacity="0"
+         id="stop285-18" />
+      <stop
+         offset=".355"
+         stop-color="#fed700"
+         stop-opacity=".515"
+         id="stop287-5" />
+      <stop
+         offset=".483"
+         stop-color="#fed208"
+         stop-opacity=".7"
+         id="stop289-9" />
+      <stop
+         offset=".857"
+         stop-color="#fed208"
+         stop-opacity="0"
+         id="stop291-7" />
+    </radialGradient>
+    <radialGradient
+       id="E-5"
+       cx="126.4"
+       cy="63.740002"
+       gradientUnits="userSpaceOnUse"
+       r="210.7"
+       xlink:href="#D" />
+    <radialGradient
+       id="G-8"
+       cx="-1402"
+       cy="-1212"
+       gradientTransform="matrix(-0.2756,0.9504,-0.6431,-0.1776,-962.9,1319)"
+       gradientUnits="userSpaceOnUse"
+       r="53.880001"
+       xlink:href="#F" />
+    <radialGradient
+       id="H-8"
+       cx="-1472"
+       cy="-1159"
+       gradientTransform="matrix(-0.3166,0.8278,-0.6529,-0.2379,-1017,1150)"
+       gradientUnits="userSpaceOnUse"
+       r="56.150002"
+       xlink:href="#F" />
+    <radialGradient
+       id="I-6"
+       cx="-1629"
+       cy="-1332"
+       gradientTransform="matrix(-0.2345,0.5201,-0.5377,-0.2307,-894.6,746.3)"
+       gradientUnits="userSpaceOnUse"
+       r="42.110001"
+       xlink:href="#F" />
+    <linearGradient
+       id="J-0"
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y1="155.7"
+       y2="346.60001">
+      <stop
+         offset="0"
+         stop-color="#e57c27"
+         id="stop322-4" />
+      <stop
+         offset=".5"
+         stop-color="#dd5626"
+         id="stop324-8" />
+      <stop
+         offset=".647"
+         stop-color="#c33a28"
+         id="stop326-88" />
+      <stop
+         offset=".75"
+         stop-color="#b02228"
+         id="stop328-9" />
+      <stop
+         offset=".813"
+         stop-color="#ab2026"
+         id="stop330-7" />
+      <stop
+         offset=".913"
+         stop-color="#9c1c21"
+         id="stop332-7" />
+      <stop
+         offset="1"
+         stop-color="#8c161a"
+         id="stop334-64" />
+    </linearGradient>
+    <radialGradient
+       id="K-30"
+       cx="2913"
+       cy="-4629"
+       gradientTransform="matrix(0.0279,-0.9996,0.9996,0.0279,4654,3343)"
+       gradientUnits="userSpaceOnUse"
+       r="111.6"
+       xlink:href="#D" />
+    <radialGradient
+       id="L-30"
+       cx="75.470001"
+       cy="84.059998"
+       gradientTransform="matrix(0.9569,0.2903,-0.1939,0.6392,19.55,8.419)"
+       gradientUnits="userSpaceOnUse"
+       r="43.93">
+      <stop
+         offset=".487"
+         stop-color="#e57c27"
+         stop-opacity="0"
+         id="stop338-9" />
+      <stop
+         offset=".853"
+         stop-color="#f0be1b"
+         id="stop340-2" />
+    </radialGradient>
+    <radialGradient
+       id="O"
+       cx="215.2"
+       cy="226.10001"
+       gradientTransform="matrix(1,0,0,-0.9811,-22.54,278.8)"
+       gradientUnits="userSpaceOnUse"
+       r="191.39999">
+      <stop
+         offset=".134"
+         stop-color="#00a3de"
+         id="stop353" />
+      <stop
+         offset=".173"
+         stop-color="#009ed9"
+         id="stop355" />
+      <stop
+         offset=".233"
+         stop-color="#0292ce"
+         id="stop357" />
+      <stop
+         offset=".307"
+         stop-color="#1d7ebe"
+         id="stop359" />
+      <stop
+         offset=".334"
+         stop-color="#2276b8"
+         id="stop361" />
+      <stop
+         offset=".44"
+         stop-color="#2468a5"
+         id="stop363" />
+      <stop
+         offset=".655"
+         stop-color="#1f4276"
+         id="stop365" />
+      <stop
+         offset=".862"
+         stop-color="#1d204e"
+         id="stop367" />
+    </radialGradient>
+    <clipPath
+       id="M">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 175.5,337.9 c 93.1,0 168.6,-75.5 168.6,-168.7 C 344.1,76 268.6,0.5 175.5,0.5 82.4,0.5 6.9,76.1 6.9,169.2 c 0,93.2 75.5,168.7 168.6,168.7 z"
+         id="path343" />
+    </clipPath>
+    <radialGradient
+       id="SVGID_1_"
+       cx="-14374.85"
+       cy="9397.75"
+       r="450.875"
+       fx="-14403.608"
+       fy="9397.75"
+       gradientTransform="matrix(0.762,0.034,0.05,-1.12,11426.936,11262.421)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="4.500000e-02"
+         style="stop-color:#FFEA00"
+         id="stop10" />
+      <stop
+         offset="0.12"
+         style="stop-color:#FFDE00"
+         id="stop12-36" />
+      <stop
+         offset="0.254"
+         style="stop-color:#FFBF00"
+         id="stop14-7" />
+      <stop
+         offset="0.429"
+         style="stop-color:#FF8E00"
+         id="stop16-5" />
+      <stop
+         offset="0.769"
+         style="stop-color:#FF272D"
+         id="stop18" />
+      <stop
+         offset="0.872"
+         style="stop-color:#E0255A"
+         id="stop20" />
+      <stop
+         offset="0.953"
+         style="stop-color:#CC2477"
+         id="stop22" />
+      <stop
+         offset="1"
+         style="stop-color:#C42482"
+         id="stop24-3" />
+    </radialGradient>
+    <linearGradient
+       id="SVGID_2_"
+       gradientUnits="userSpaceOnUse"
+       x1="575.64893"
+       y1="294.80591"
+       x2="384.21091"
+       y2="921.03387"
+       gradientTransform="matrix(1,0,0,-1,0,1026)">
+      <stop
+         offset="0"
+         style="stop-color:#000F43;stop-opacity:0.4"
+         id="stop29-5" />
+      <stop
+         offset="0.485"
+         style="stop-color:#001962;stop-opacity:0.173"
+         id="stop31-6" />
+      <stop
+         offset="1"
+         style="stop-color:#002079;stop-opacity:0"
+         id="stop33-2" />
+    </linearGradient>
+    <radialGradient
+       id="SVGID_3_"
+       cx="-8291.3574"
+       cy="7620.0073"
+       r="266.88599"
+       gradientTransform="matrix(1.219,0.123,0.123,-1.219,10197.618,10946.078)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="3.000000e-03"
+         style="stop-color:#FFEA00"
+         id="stop38" />
+      <stop
+         offset="0.497"
+         style="stop-color:#FF272D"
+         id="stop40" />
+      <stop
+         offset="1"
+         style="stop-color:#C42482"
+         id="stop42-9" />
+    </radialGradient>
+    <radialGradient
+       id="SVGID_4_"
+       cx="-8315.5039"
+       cy="7875.9189"
+       r="445.67801"
+       gradientTransform="matrix(1.219,0.123,0.123,-1.219,10197.618,10946.078)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="3.000000e-03"
+         style="stop-color:#FFE900"
+         id="stop47" />
+      <stop
+         offset="0.157"
+         style="stop-color:#FFAF0E"
+         id="stop49" />
+      <stop
+         offset="0.316"
+         style="stop-color:#FF7A1B"
+         id="stop51" />
+      <stop
+         offset="0.472"
+         style="stop-color:#FF4E26"
+         id="stop53" />
+      <stop
+         offset="0.621"
+         style="stop-color:#FF2C2E"
+         id="stop55" />
+      <stop
+         offset="0.762"
+         style="stop-color:#FF1434"
+         id="stop57" />
+      <stop
+         offset="0.892"
+         style="stop-color:#FF0538"
+         id="stop59" />
+      <stop
+         offset="1"
+         style="stop-color:#FF0039"
+         id="stop61" />
+    </radialGradient>
+    <radialGradient
+       id="SVGID_5_"
+       cx="-8252.4678"
+       cy="7462.7832"
+       r="408.95801"
+       gradientTransform="matrix(1.219,0.123,0.123,-1.219,10197.618,10946.078)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="3.000000e-03"
+         style="stop-color:#FF272D"
+         id="stop66-12" />
+      <stop
+         offset="0.497"
+         style="stop-color:#C42482"
+         id="stop68" />
+      <stop
+         offset="0.986"
+         style="stop-color:#620700"
+         id="stop70" />
+    </radialGradient>
+    <radialGradient
+       id="SVGID_6_"
+       cx="750.18903"
+       cy="629.95898"
+       r="782.17999"
+       fx="778.1665"
+       fy="616.13037"
+       gradientTransform="matrix(1,0,0,-1,0,1026)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0.156"
+         style="stop-color:#FFEA00"
+         id="stop75-7" />
+      <stop
+         offset="0.231"
+         style="stop-color:#FFDE00"
+         id="stop77" />
+      <stop
+         offset="0.365"
+         style="stop-color:#FFBF00"
+         id="stop79" />
+      <stop
+         offset="0.541"
+         style="stop-color:#FF8E00"
+         id="stop81" />
+      <stop
+         offset="0.763"
+         style="stop-color:#FF272D"
+         id="stop83" />
+      <stop
+         offset="0.796"
+         style="stop-color:#F92433"
+         id="stop85" />
+      <stop
+         offset="0.841"
+         style="stop-color:#E91C45"
+         id="stop87" />
+      <stop
+         offset="0.893"
+         style="stop-color:#CF0E62"
+         id="stop89" />
+      <stop
+         offset="0.935"
+         style="stop-color:#B5007F"
+         id="stop91-0" />
+    </radialGradient>
+    <radialGradient
+       id="SVGID_7_"
+       cx="691.33899"
+       cy="1022.711"
+       r="923.61499"
+       gradientTransform="matrix(1,0,0,-1,0,1026)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0.279"
+         style="stop-color:#FFEA00"
+         id="stop96" />
+      <stop
+         offset="0.402"
+         style="stop-color:#FFDD00"
+         id="stop98" />
+      <stop
+         offset="0.63"
+         style="stop-color:#FFBA00"
+         id="stop100" />
+      <stop
+         offset="0.856"
+         style="stop-color:#FF9100"
+         id="stop102" />
+      <stop
+         offset="0.933"
+         style="stop-color:#FF6711"
+         id="stop104" />
+      <stop
+         offset="0.994"
+         style="stop-color:#FF4A1D"
+         id="stop106" />
+    </radialGradient>
+    <linearGradient
+       id="SVGID_8_"
+       gradientUnits="userSpaceOnUse"
+       x1="-8974.0137"
+       y1="7777.0605"
+       x2="-8689.6523"
+       y2="7849.5444"
+       gradientTransform="matrix(1.219,0.123,0.123,-1.219,10197.618,10946.078)">
+      <stop
+         offset="0"
+         style="stop-color:#C42482;stop-opacity:0.5"
+         id="stop111-93" />
+      <stop
+         offset="0.474"
+         style="stop-color:#FF272D;stop-opacity:0.5"
+         id="stop113" />
+      <stop
+         offset="0.486"
+         style="stop-color:#FF2C2C;stop-opacity:0.513"
+         id="stop115" />
+      <stop
+         offset="0.675"
+         style="stop-color:#FF7A1A;stop-opacity:0.72"
+         id="stop117" />
+      <stop
+         offset="0.829"
+         style="stop-color:#FFB20D;stop-opacity:0.871"
+         id="stop119" />
+      <stop
+         offset="0.942"
+         style="stop-color:#FFD605;stop-opacity:0.964"
+         id="stop121" />
+      <stop
+         offset="1"
+         style="stop-color:#FFE302"
+         id="stop123" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_9_"
+       gradientUnits="userSpaceOnUse"
+       x1="272.6861"
+       y1="2138.1853"
+       x2="218.11411"
+       y2="2278.0325"
+       gradientTransform="matrix(0.995,0.1,0.1,-0.995,-306.431,2362.0759)">
+      <stop
+         offset="0"
+         style="stop-color:#891551;stop-opacity:0.6"
+         id="stop128-60" />
+      <stop
+         offset="1"
+         style="stop-color:#C42482;stop-opacity:0"
+         id="stop130-6" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_10_"
+       gradientUnits="userSpaceOnUse"
+       x1="49.2551"
+       y1="337.27731"
+       x2="143.3631"
+       y2="230.3904"
+       gradientTransform="matrix(0.995,0.1,0.1,-0.995,172.704,801.664)">
+      <stop
+         offset="5.000000e-03"
+         style="stop-color:#891551;stop-opacity:0.5"
+         id="stop135" />
+      <stop
+         offset="0.484"
+         style="stop-color:#FF272D;stop-opacity:0.5"
+         id="stop137-2" />
+      <stop
+         offset="1"
+         style="stop-color:#FF272D;stop-opacity:0"
+         id="stop139-61" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_11_"
+       gradientUnits="userSpaceOnUse"
+       x1="227.2766"
+       y1="151.5255"
+       x2="227.3436"
+       y2="226.3065"
+       gradientTransform="matrix(0.995,0.1,0.1,-0.995,172.704,801.664)">
+      <stop
+         offset="0"
+         style="stop-color:#C42482"
+         id="stop144" />
+      <stop
+         offset="8.299999e-02"
+         style="stop-color:#C42482;stop-opacity:0.81"
+         id="stop146-87" />
+      <stop
+         offset="0.206"
+         style="stop-color:#C42482;stop-opacity:0.565"
+         id="stop148-92" />
+      <stop
+         offset="0.328"
+         style="stop-color:#C42482;stop-opacity:0.362"
+         id="stop150-0" />
+      <stop
+         offset="0.447"
+         style="stop-color:#C42482;stop-opacity:0.204"
+         id="stop152-2" />
+      <stop
+         offset="0.562"
+         style="stop-color:#C42482;stop-opacity:9.100000e-02"
+         id="stop154-3" />
+      <stop
+         offset="0.673"
+         style="stop-color:#C42482;stop-opacity:2.300000e-02"
+         id="stop156-75" />
+      <stop
+         offset="0.773"
+         style="stop-color:#C42482;stop-opacity:0"
+         id="stop158-9" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_12_"
+       gradientUnits="userSpaceOnUse"
+       x1="655.5307"
+       y1="987.87988"
+       x2="961.18671"
+       y2="304.38489"
+       gradientTransform="matrix(1,0,0,-1,0,1026)">
+      <stop
+         offset="0"
+         style="stop-color:#FFF14F"
+         id="stop163-2" />
+      <stop
+         offset="0.268"
+         style="stop-color:#FFEE4C"
+         id="stop165-2" />
+      <stop
+         offset="0.452"
+         style="stop-color:#FFE643"
+         id="stop167" />
+      <stop
+         offset="0.612"
+         style="stop-color:#FFD834"
+         id="stop169" />
+      <stop
+         offset="0.757"
+         style="stop-color:#FFC41E"
+         id="stop171" />
+      <stop
+         offset="0.892"
+         style="stop-color:#FFAB02"
+         id="stop173" />
+      <stop
+         offset="0.902"
+         style="stop-color:#FFA900"
+         id="stop175-8" />
+      <stop
+         offset="0.949"
+         style="stop-color:#FFA000"
+         id="stop177-97" />
+      <stop
+         offset="1"
+         style="stop-color:#FF9100"
+         id="stop179-3" />
+    </linearGradient>
+    <linearGradient
+       id="SVGID_13_"
+       gradientUnits="userSpaceOnUse"
+       x1="715.88519"
+       y1="594.78992"
+       x2="571.09821"
+       y2="206.0399"
+       gradientTransform="matrix(1,0,0,-1,0,1026)">
+      <stop
+         offset="0"
+         style="stop-color:#FF8E00"
+         id="stop184" />
+      <stop
+         offset="4.000000e-02"
+         style="stop-color:#FF8E00;stop-opacity:0.858"
+         id="stop186-61" />
+      <stop
+         offset="8.400000e-02"
+         style="stop-color:#FF8E00;stop-opacity:0.729"
+         id="stop188-2" />
+      <stop
+         offset="0.13"
+         style="stop-color:#FF8E00;stop-opacity:0.628"
+         id="stop190-93" />
+      <stop
+         offset="0.178"
+         style="stop-color:#FF8E00;stop-opacity:0.557"
+         id="stop192-19" />
+      <stop
+         offset="0.227"
+         style="stop-color:#FF8E00;stop-opacity:0.514"
+         id="stop194-4" />
+      <stop
+         offset="0.282"
+         style="stop-color:#FF8E00;stop-opacity:0.5"
+         id="stop196-78" />
+      <stop
+         offset="0.389"
+         style="stop-color:#FF8E00;stop-opacity:0.478"
+         id="stop198-4" />
+      <stop
+         offset="0.524"
+         style="stop-color:#FF8E00;stop-opacity:0.416"
+         id="stop200-5" />
+      <stop
+         offset="0.676"
+         style="stop-color:#FF8E00;stop-opacity:0.314"
+         id="stop202-03" />
+      <stop
+         offset="0.838"
+         style="stop-color:#FF8E00;stop-opacity:0.172"
+         id="stop204-6" />
+      <stop
+         offset="1"
+         style="stop-color:#FF8E00;stop-opacity:0"
+         id="stop206-1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.6210938"
+     inkscape:cx="69.648669"
+     inkscape:cy="122.43448"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer4"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1054"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2168" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1485">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Livello 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-229.26666)">
+    <g
+       style="enable-background:new"
+       id="layer4"
+       transform="matrix(0.12974173,0,0,0.12974173,3.8344818,227.85345)">
+      <g
+         transform="matrix(4.8373097,0,0,4.8373097,-641.70983,256.01947)"
+         id="g983" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path4567"
+         d="m 162.53675,3.5680001 c 72.64865,0 83.03125,10.3566149 83.03125,82.9375049 l 0,58.125005 c 0,72.58059 -10.3826,82.9375 -83.03125,82.9375 l -73.937496,0 C 15.9506,227.56801 5.568,217.2111 5.568,144.63051 l 0,-58.125005 c 0,-72.58089 10.3826,-82.9375049 83.031254,-82.9375049 z"
+         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4569);enable-background:new"
+         transform="matrix(2.0393079,0,0,2.0393079,-24.59515,36.245182)" />
+      <path
+         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter989);enable-background:new"
+         d="m 5.5683594,101.36914 0,56.125 c 0,9.07257 0.1620995,17.17296 0.5878906,24.40234 0.2128956,3.6147 0.4922655,7.01124 0.8496094,10.20313 0.3573439,3.19188 0.7931865,6.18021 1.3203125,8.97461 0.527126,2.7944 1.1449457,5.39611 1.8671871,7.81836 0.722242,2.42224 1.547543,4.66482 2.490235,6.74023 0.942691,2.07541 2.002932,3.98242 3.191406,5.73633 1.188474,1.75391 2.505252,3.35478 3.964844,4.8125 1.459591,1.45773 3.062317,2.77211 4.818359,3.95898 1.756042,1.18688 3.666314,2.24616 5.744141,3.1875 2.077826,0.94135 4.323102,1.7652 6.748047,2.48633 2.424944,0.72114 5.028775,1.33898 7.826171,1.86524 2.797397,0.52626 5.787241,0.96165 8.982422,1.31836 3.195182,0.3567 6.596543,0.63518 10.214844,0.84765 7.236602,0.42496 15.3447,0.58594 24.425781,0.58594 l 73.937501,0 c 9.08108,0 17.18918,-0.16098 24.42578,-0.58594 3.6183,-0.21247 7.01771,-0.49095 10.21289,-0.84765 3.19518,-0.35671 6.18503,-0.7921 8.98242,-1.31836 2.7974,-0.52626 5.40318,-1.1441 7.82813,-1.86524 2.42494,-0.72113 4.67022,-1.54498 6.74805,-2.48633 2.07782,-0.94134 3.98809,-2.00062 5.74414,-3.1875 1.75604,-1.18687 3.35681,-2.50125 4.8164,-3.95898 1.45959,-1.45772 2.77832,-3.05859 3.9668,-4.8125 1.18847,-1.75391 2.24676,-3.66092 3.18945,-5.73633 0.94269,-2.07541 1.76995,-4.31799 2.49219,-6.74023 0.72224,-2.42225 1.34006,-5.02396 1.86719,-7.81836 0.52712,-2.7944 0.96297,-5.78273 1.32031,-8.97461 0.35734,-3.19189 0.63671,-6.58843 0.84961,-10.20313 0.42579,-7.22938 0.58789,-15.32977 0.58789,-24.40234 l 0,-56.125 c 0,-72.58089 -10.3826,-82.937499 -83.03125,-82.937499 l -73.937501,0 c -72.648654,0 -83.0312496,10.356609 -83.0312496,82.937499 z"
+         id="path979"
+         transform="matrix(2.0393079,0,0,2.0393079,-24.595863,7.9729296)"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;opacity:1;fill:url(#linearGradient1048);fill-opacity:1;stroke:none;stroke-width:4.07861567;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="m 306.86733,43.521412 c 148.15296,0 169.32628,21.120327 169.32628,169.135108 l 0,118.53478 c 0,148.01417 -21.17332,169.1351 -169.32628,169.1351 l -150.78132,0 c -148.1529568,0 -169.326277,-21.12093 -169.326277,-169.1351 l 0,-118.53478 c 0,-148.014781 21.1733202,-169.135108 169.326277,-169.135108 z"
+         id="rect877"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1068"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 l 0,116.25 C 528,215.28618 507.2348,236 361.9375,236 l -147.875,0 C 68.7652,236 48,215.28618 48,70.125 l 0,-116.25 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:0.5;fill:none;fill-opacity:1;stroke:url(#linearGradient1108);stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         clip-path="url(#clipPath1082-3-367)"
+         transform="matrix(1.0196539,0,0,1.0196539,-62.18365,259.68806)" />
+      <g
+         style="fill:#000000;fill-opacity:0.00478468;filter:url(#filter5684);enable-background:new"
+         transform="matrix(1.3000209,0,0,1.300021,2.5930966,33.729534)"
+         id="g4815-6">
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path427-0"
+           d="M 46.8,52.2 C 46.4,51.6 46.4,53.7 46,53 43.3,48.2 41.1,40 40.8,34.2 c 0,0 -4.4,2.5 -7.2,11.5 -0.5,1.6 -0.9,2.5 -1.2,3.4 -0.1,0.3 0.2,-2.9 0.1,-2.6 -0.5,1.1 -2.1,2.9 -2.6,4.9 -0.4,1.6 -1,2.5 -1.3,4.5 -0.1,0.6 -0.1,-2.4 -0.2,-1.9 -3.7,9.8 -6.7,23.6 -5,42.3 C 40.1,81.3 63.8,70 63.8,70 61.1,68.3 52.7,61.7 46.8,52.2 Z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path429-4"
+           d="m 3,203.5 c 0.2,-2.8 7,-59.4 33.2,-78.5 22.6,-16.5 5,-10.5 -3.7,-9.8 -9.2,0.7 -14.1,6.3 -12.3,4.3 0.1,-0.1 0.1,-0.1 0.1,-0.2 C 20,118.9 -1.3,136.8 3,203.5 Z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path431-8"
+           d="m 0,159.3 c 0,0 15.4,-49 46.6,-48.5 20.7,0.3 4.3,-17.5 -2,-20.2 -6.5,-2.8 -8.1,-2.7 -9.6,-1.3 -2.3,2 -22.8,1.2 -35,70 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path433-8"
+           d="m 285.7,35.9 c 0,0 14.7,7.1 24.2,22.3 7.8,12.4 4.1,29.1 -2.9,26.2 -6.9,-2.9 -21.3,-48.5 -21.3,-48.5 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path435-8"
+           d="m 311,86 c 4.1,-31.5 -25.4,-50.2 -25.4,-50.2 0,0 1.9,10.8 4.2,34.8 2.8,27.5 19.3,30.2 21.2,15.4 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path437-9"
+           d="m 212.2,329.1 c 53.3,11.3 93.6,-33.7 64.8,-44.5 -26.1,-9.8 -90.1,39.1 -64.8,44.5 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path439-7"
+           d="m 281.7,286 c 53.2,-11.6 71.4,-69.2 40.8,-67.2 -27.8,1.8 -66,72.7 -40.8,67.2 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path441-7"
+           d="m 328.9,196.4 c 34.9,-25.2 18.3,-70 18.3,-70 0,0 -7.7,23.1 -14.7,50.3 -6.9,27.1 -24.5,34.8 -3.6,19.7 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path443-6"
+           d="m 339.3,118.1 c -3.7,-43.2 -30.5,-65.6 -30.5,-65.6 0,0 2.7,14.7 6.3,34.8 4.8,27.5 26.4,56.5 24.2,30.8 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path451-4"
+           d="m 177.6,205.1 c -1,1 0.1,3.9 1.4,3.8 1.3,-0.1 3.2,-0.7 3.2,-0.7 0,0 1,1.9 0,2.5 -1,0.5 -3.8,0.3 -0.1,1.7 3.8,1.4 4.8,1 5,0.3 0.3,-0.7 1.5,-3.1 2.2,-2.9 0.6,-1.2 -2,-2.4 -0.6,-3.2 1.4,-0.8 0.3,-3.9 0.3,-3.9 0,0 -2,0.1 -2.8,1.5 -0.8,1.4 -2,-0.1 -2.8,-0.1 -0.1,0.8 -0.7,1.5 -0.7,1.5 l -0.6,-1.3 c 0.1,-0.1 -3.8,-0.2 -4.5,0.8 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path459-3"
+           d="m 303.4,269.6 c 9.7,-18.2 22.8,-28.9 29.9,-41.5 9.4,-16.8 27.3,-63.9 13.8,-102 6.2,23.8 4.2,48 -15.4,60.2 6.4,-16.8 10.3,-53.6 3.8,-86.8 -4.3,-21.6 -17.8,-40.9 -26.5,-46.9 8.1,6.1 14.6,27.8 14.4,37.8 C 306.5,61.9 278.8,34.6 237,23.1 269.5,44.5 281.6,62.7 289.2,78.9 280.5,70 265.7,60.8 255.6,60 c 15,11.2 40.2,44.4 37.5,94.7 -3.9,-8.1 -10.9,-20.8 -15.9,-25.2 5.4,49.4 0.7,60 -2.6,73.1 -0.7,-6 -2.9,-10.6 -4.1,-13.3 0,0 -0.6,15.4 -10.6,37.4 -7.6,16.7 -15.4,21.8 -18.9,21.2 -0.9,-0.1 -1.4,-0.5 -1.4,-0.5 0.2,-2.2 0.5,-4.4 -0.1,-5.9 0,0 -3.2,1.1 -5.3,4 -0.8,1.2 -1.9,2.3 -3.3,3.4 -0.2,0.2 2.3,-3.2 2.1,-3.1 -1.2,1 -2.6,2.2 -3.9,3.6 -4.9,5.1 -9.4,10.8 -11.7,9.2 2.1,-0.7 3.9,-3.4 4.3,-6.1 -1.9,1.4 -6.8,5 -17.8,6.7 -4.5,0.7 -23.6,4.2 -49.1,-8.6 3.7,-0.4 9.3,-1.7 13.5,0.8 -4.2,-4.6 -14.5,-3.7 -21.8,-6 -6.4,-2 -14.7,-11 -19.5,-15.5 19.6,4.8 40.4,1.3 52.4,-6.9 12.2,-8.3 19.4,-14.4 25.8,-12.9 6.4,1.4 10.7,-5 5.7,-10.8 -5,-5.8 -17.2,-13.5 -33.7,-9.4 -12.7,3.2 -23.4,13.3 -41.2,6.3 -1.1,-0.4 -2.2,-0.9 -3.3,-1.5 -1.1,-0.6 3.7,0.7 2.5,0 -3.4,-1.3 -9.6,-4.1 -11.2,-5.2 -0.3,-0.2 2.6,0.5 2.3,0.3 -16.9,-10 -15.8,-18 -15.8,-22.9 0,-4 2.4,-9.3 6.9,-11.8 2.4,0.9 3.9,1.7 3.9,1.7 0,0 -1.1,-1.7 -1.8,-2.6 0.2,-0.1 0.3,-0.1 0.5,-0.2 2,0.7 6.5,2.3 8.7,3.5 3.1,1.5 4.1,3.1 4.1,3.1 0,0 0.7,-0.5 0,-2 -0.3,-0.7 -1.4,-2.6 -4.4,-4.4 l 0.1,0 c 1.6,0.6 3.3,1.4 5.1,2.5 0.6,-2.7 1.7,-5.5 1,-10.4 -0.6,-3.5 -0.5,-4.3 -1.3,-5.6 -0.7,-1.1 0.2,-1.5 1.3,-0.6 -0.3,-0.9 -0.7,-1.7 -1.1,-2.6 0.9,-4.3 26.3,-17.6 28.2,-19 2.6,-1.9 5.3,-4.9 7,-8.4 1.2,-2.2 2.1,-5.3 1.9,-9.9 -0.2,-3.3 -2.1,-5.3 -29.2,-5 -7.4,0.1 -12.2,-4.2 -15.1,-8.3 -0.6,-0.9 -1.1,-1.7 -1.6,-2.5 -0.6,-1.1 -1.1,-2.2 -1.4,-3 3.2,-11.7 9.7,-21.9 19.8,-30.2 0.6,-0.5 -2.4,0.3 -1.8,-0.2 0.7,-0.6 5,-2.7 5.8,-3.1 1,-0.6 -4.7,-2.1 -9.5,-1.1 -4.9,1 -5.8,1.6 -8.4,2.9 1,-1.1 4.3,-2.7 3.5,-2.6 -5.3,1.2 -11.6,4.7 -16.9,8.4 0,-0.5 0,-0.9 0.1,-1.6 -2.5,1.3 -8.6,6 -10.1,9.5 0,-0.8 0,-1.2 -0.1,-2 -1.7,1.6 -3.4,3.5 -4.9,5.5 0,0 0,0.1 -0.1,0.1 C 84.9,63.1 71.5,64 60.2,67.6 57.5,65.7 53.2,62.7 46.4,52.2 46,51.6 46,53.6 45.6,53 42.9,48.2 40.7,40 40.4,34.2 c 0,0 -4.4,2.5 -7.2,11.5 -0.5,1.6 -0.9,2.5 -1.2,3.4 -0.1,0.3 0.2,-2.9 0.1,-2.6 -0.5,1.1 -2.1,2.9 -2.6,4.9 -0.4,1.5 -1,2.4 -1.2,4.3 0,0 0,0.1 -0.1,0.1 0,-0.5 -0.1,-2.2 -0.2,-1.9 -1.3,3.3 -2.4,7.1 -3.4,11.4 -1.4,6.8 -2.8,16.1 -1.9,27.9 0,1 0.1,1.9 0.1,2.7 -4.3,5.9 -7,10.9 -8.1,13.4 -5.2,10.1 -10.5,25.7 -14.8,49.9 0,0 2.9,-9.1 8.6,-19.4 -4.2,13 -7.6,33.2 -5.6,63.5 0.1,-1 1,-8.7 3.2,-19 1.1,20.2 5.9,44.9 21.6,71.8 12,20.5 43.5,68.1 122.6,85.9 -8.7,-2.5 -14.1,-7.5 -14.1,-7.5 0,0 29.6,9.5 51.1,8.7 -6.8,-1.2 -8.1,-4.4 -8.1,-4.4 0,0 76.7,4.3 103.2,-31.8 -9.1,10.6 -32,13.6 -40.7,13.7 13.2,-12.1 42.4,-11.9 74.1,-43 17.4,-17.1 19.2,-30.1 21.1,-42.2 -2.5,15.8 -17.7,25.4 -33.5,34.1 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path461-0"
+           d="m 303.4,269.6 c 9.7,-18.2 22.8,-28.9 29.9,-41.5 9.4,-16.8 27.3,-63.9 13.8,-102 6.2,23.8 4.2,48 -15.4,60.2 6.4,-16.8 10.3,-53.6 3.8,-86.8 -4.3,-21.6 -17.8,-40.9 -26.5,-46.9 8.1,6.1 14.6,27.8 14.4,37.8 C 306.5,61.9 278.8,34.6 237,23.1 269.5,44.5 281.6,62.7 289.2,78.9 280.5,70 265.7,60.8 255.6,60 c 15,11.2 40.2,44.4 37.5,94.7 -3.9,-8.1 -10.9,-20.8 -15.9,-25.2 5.4,49.4 0.7,60 -2.6,73.1 -0.7,-6 -2.9,-10.6 -4.1,-13.3 0,0 -0.6,15.4 -10.6,37.4 -7.6,16.7 -15.4,21.8 -18.9,21.2 -0.9,-0.1 -1.4,-0.5 -1.4,-0.5 0.2,-2.2 0.5,-4.4 -0.1,-5.9 0,0 -3.2,1.1 -5.3,4 -0.8,1.2 -1.9,2.3 -3.3,3.4 -0.2,0.2 2.3,-3.2 2.1,-3.1 -1.2,1 -2.6,2.2 -3.9,3.6 -4.9,5.1 -9.4,10.8 -11.7,9.2 2.1,-0.7 3.9,-3.4 4.3,-6.1 -1.9,1.4 -6.8,5 -17.8,6.7 -4.5,0.7 -23.6,4.2 -49.1,-8.6 3.7,-0.4 9.3,-1.7 13.5,0.8 -4.2,-4.6 -14.5,-3.7 -21.8,-6 -6.4,-2 -14.7,-11 -19.5,-15.5 19.6,4.8 40.4,1.3 52.4,-6.9 12.2,-8.3 19.4,-14.4 25.8,-12.9 6.4,1.4 10.7,-5 5.7,-10.8 -5,-5.8 -17.2,-13.5 -33.7,-9.4 -12.7,3.2 -23.4,13.3 -41.2,6.3 -1.1,-0.4 -2.2,-0.9 -3.3,-1.5 -1.1,-0.6 3.7,0.7 2.5,0 -3.4,-1.3 -9.6,-4.1 -11.2,-5.2 -0.3,-0.2 2.6,0.5 2.3,0.3 -16.9,-10 -15.8,-18 -15.8,-22.9 0,-4 2.4,-9.3 6.9,-11.8 2.4,0.9 3.9,1.7 3.9,1.7 0,0 -1.1,-1.7 -1.8,-2.6 0.2,-0.1 0.3,-0.1 0.5,-0.2 2,0.7 6.5,2.3 8.7,3.5 3.1,1.5 4.1,3.1 4.1,3.1 0,0 0.7,-0.5 0,-2 -0.3,-0.7 -1.4,-2.6 -4.4,-4.4 l 0.1,0 c 1.6,0.6 3.3,1.4 5.1,2.5 0.6,-2.7 1.7,-5.5 1,-10.4 -0.6,-3.5 -0.5,-4.3 -1.3,-5.6 -0.7,-1.1 0.2,-1.5 1.3,-0.6 -0.3,-0.9 -0.7,-1.7 -1.1,-2.6 0.9,-4.3 26.3,-17.6 28.2,-19 2.6,-1.9 5.3,-4.9 7,-8.4 1.2,-2.2 2.1,-5.3 1.9,-9.9 -0.2,-3.3 -2.1,-5.3 -29.2,-5 -7.4,0.1 -12.2,-4.2 -15.1,-8.3 -0.6,-0.9 -1.1,-1.7 -1.6,-2.5 -0.6,-1.1 -1.1,-2.2 -1.4,-3 3.2,-11.7 9.7,-21.9 19.8,-30.2 0.6,-0.5 -2.4,0.3 -1.8,-0.2 0.7,-0.6 5,-2.7 5.8,-3.1 1,-0.6 -4.7,-2.1 -9.5,-1.1 -4.9,1 -5.8,1.6 -8.4,2.9 1,-1.1 4.3,-2.7 3.5,-2.6 -5.3,1.2 -11.6,4.7 -16.9,8.4 0,-0.5 0,-0.9 0.1,-1.6 -2.5,1.3 -8.6,6 -10.1,9.5 0,-0.8 0,-1.2 -0.1,-2 -1.7,1.6 -3.4,3.5 -4.9,5.5 0,0 0,0.1 -0.1,0.1 C 84.9,63.1 71.5,64 60.2,67.6 57.5,65.7 53.2,62.7 46.4,52.2 46,51.6 46,53.6 45.6,53 42.9,48.2 40.7,40 40.4,34.2 c 0,0 -4.4,2.5 -7.2,11.5 -0.5,1.6 -0.9,2.5 -1.2,3.4 -0.1,0.3 0.2,-2.9 0.1,-2.6 -0.5,1.1 -2.1,2.9 -2.6,4.9 -0.4,1.5 -1,2.4 -1.2,4.3 0,0 0,0.1 -0.1,0.1 0,-0.5 -0.1,-2.2 -0.2,-1.9 -1.3,3.3 -2.4,7.1 -3.4,11.4 -1.4,6.8 -2.8,16.1 -1.9,27.9 0,1 0.1,1.9 0.1,2.7 -4.3,5.9 -7,10.9 -8.1,13.4 -5.2,10.1 -10.5,25.7 -14.8,49.9 0,0 2.9,-9.1 8.6,-19.4 -4.2,13 -7.6,33.2 -5.6,63.5 0.1,-1 1,-8.7 3.2,-19 1.1,20.2 5.9,44.9 21.6,71.8 12,20.5 43.5,68.1 122.6,85.9 -8.7,-2.5 -14.1,-7.5 -14.1,-7.5 0,0 29.6,9.5 51.1,8.7 -6.8,-1.2 -8.1,-4.4 -8.1,-4.4 0,0 76.7,4.3 103.2,-31.8 -9.1,10.6 -32,13.6 -40.7,13.7 13.2,-12.1 42.4,-11.9 74.1,-43 17.4,-17.1 19.2,-30.1 21.1,-42.2 -2.5,15.8 -17.7,25.4 -33.5,34.1 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path463-3"
+           d="m 303.4,269.6 c 9.7,-18.2 22.8,-28.9 29.9,-41.5 9.4,-16.8 27.3,-63.9 13.8,-102 6.2,23.8 4.2,48 -15.4,60.2 6.4,-16.8 10.3,-53.6 3.8,-86.8 -4.3,-21.6 -17.8,-40.9 -26.5,-46.9 8.1,6.1 14.6,27.8 14.4,37.8 C 306.5,61.9 278.8,34.6 237,23.1 269.5,44.5 281.6,62.7 289.2,78.9 280.5,70 265.7,60.8 255.6,60 c 15,11.2 40.2,44.4 37.5,94.7 -3.9,-8.1 -10.9,-20.8 -15.9,-25.2 5.4,49.4 0.7,60 -2.6,73.1 -0.7,-6 -2.9,-10.6 -4.1,-13.3 0,0 -0.6,15.4 -10.6,37.4 -7.6,16.7 -15.4,21.8 -18.9,21.2 -0.9,-0.1 -1.4,-0.5 -1.4,-0.5 0.2,-2.2 0.5,-4.4 -0.1,-5.9 0,0 -3.2,1.1 -5.3,4 -0.8,1.2 -1.9,2.3 -3.3,3.4 -0.2,0.2 2.3,-3.2 2.1,-3.1 -1.2,1 -2.6,2.2 -3.9,3.6 -4.9,5.1 -9.4,10.8 -11.7,9.2 2.1,-0.7 3.9,-3.4 4.3,-6.1 -1.9,1.4 -6.8,5 -17.8,6.7 -4.5,0.7 -23.6,4.2 -49.1,-8.6 3.7,-0.4 9.3,-1.7 13.5,0.8 -4.2,-4.6 -14.5,-3.7 -21.8,-6 -6.4,-2 -14.7,-11 -19.5,-15.5 19.6,4.8 40.4,1.3 52.4,-6.9 12.2,-8.3 19.4,-14.4 25.8,-12.9 6.4,1.4 10.7,-5 5.7,-10.8 -5,-5.8 -17.2,-13.5 -33.7,-9.4 -12.7,3.2 -23.4,13.3 -41.2,6.3 -1.1,-0.4 -2.2,-0.9 -3.3,-1.5 -1.1,-0.6 3.7,0.7 2.5,0 -3.4,-1.3 -9.6,-4.1 -11.2,-5.2 -0.3,-0.2 2.6,0.5 2.3,0.3 -16.9,-10 -15.8,-18 -15.8,-22.9 0,-4 2.4,-9.3 6.9,-11.8 2.4,0.9 3.9,1.7 3.9,1.7 0,0 -1.1,-1.7 -1.8,-2.6 0.2,-0.1 0.3,-0.1 0.5,-0.2 2,0.7 6.5,2.3 8.7,3.5 3.1,1.5 4.1,3.1 4.1,3.1 0,0 0.7,-0.5 0,-2 -0.3,-0.7 -1.4,-2.6 -4.4,-4.4 l 0.1,0 c 1.6,0.6 3.3,1.4 5.1,2.5 0.6,-2.7 1.7,-5.5 1,-10.4 -0.6,-3.5 -0.5,-4.3 -1.3,-5.6 -0.7,-1.1 0.2,-1.5 1.3,-0.6 -0.3,-0.9 -0.7,-1.7 -1.1,-2.6 0.9,-4.3 26.3,-17.6 28.2,-19 2.6,-1.9 5.3,-4.9 7,-8.4 1.2,-2.2 2.1,-5.3 1.9,-9.9 -0.2,-3.3 -2.1,-5.3 -29.2,-5 -7.4,0.1 -12.2,-4.2 -15.1,-8.3 -0.6,-0.9 -1.1,-1.7 -1.6,-2.5 -0.6,-1.1 -1.1,-2.2 -1.4,-3 3.2,-11.7 9.7,-21.9 19.8,-30.2 0.6,-0.5 -2.4,0.3 -1.8,-0.2 0.7,-0.6 5,-2.7 5.8,-3.1 1,-0.6 -4.7,-2.1 -9.5,-1.1 -4.9,1 -5.8,1.6 -8.4,2.9 1,-1.1 4.3,-2.7 3.5,-2.6 -5.3,1.2 -11.6,4.7 -16.9,8.4 0,-0.5 0,-0.9 0.1,-1.6 -2.5,1.3 -8.6,6 -10.1,9.5 0,-0.8 0,-1.2 -0.1,-2 -1.7,1.6 -3.4,3.5 -4.9,5.5 0,0 0,0.1 -0.1,0.1 C 84.9,63.1 71.5,64 60.2,67.6 57.5,65.7 53.2,62.7 46.4,52.2 46,51.6 46,53.6 45.6,53 42.9,48.2 40.7,40 40.4,34.2 c 0,0 -4.4,2.5 -7.2,11.5 -0.5,1.6 -0.9,2.5 -1.2,3.4 -0.1,0.3 0.2,-2.9 0.1,-2.6 -0.5,1.1 -2.1,2.9 -2.6,4.9 -0.4,1.5 -1,2.4 -1.2,4.3 0,0 0,0.1 -0.1,0.1 0,-0.5 -0.1,-2.2 -0.2,-1.9 -1.3,3.3 -2.4,7.1 -3.4,11.4 -1.4,6.8 -2.8,16.1 -1.9,27.9 0,1 0.1,1.9 0.1,2.7 -4.3,5.9 -7,10.9 -8.1,13.4 -5.2,10.1 -10.5,25.7 -14.8,49.9 0,0 2.9,-9.1 8.6,-19.4 -4.2,13 -7.6,33.2 -5.6,63.5 0.1,-1 1,-8.7 3.2,-19 1.1,20.2 5.9,44.9 21.6,71.8 12,20.5 43.5,68.1 122.6,85.9 -8.7,-2.5 -14.1,-7.5 -14.1,-7.5 0,0 29.6,9.5 51.1,8.7 -6.8,-1.2 -8.1,-4.4 -8.1,-4.4 0,0 76.7,4.3 103.2,-31.8 -9.1,10.6 -32,13.6 -40.7,13.7 13.2,-12.1 42.4,-11.9 74.1,-43 17.4,-17.1 19.2,-30.1 21.1,-42.2 -2.5,15.8 -17.7,25.4 -33.5,34.1 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path465-0"
+           d="m 171,100.4 c -0.2,-3.3 -2.3,-5.6 -29.4,-5.4 -11.1,0.1 -16.3,-9.6 -18.1,-13.7 -2.9,10.5 -3.4,21.3 -1.2,34 1.4,8.4 7.4,15.5 10.7,20.5 0.8,0.8 1.2,1 1.4,0.5 1.2,-2.6 25,-16.1 26.9,-17.6 2,-1.3 10.2,-8.3 9.7,-18.3 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path467-9"
+           d="m 133.9,97.3 c 0,0 9.4,4.6 10.8,7.5 0.4,0.9 -4.8,-1.6 -4.5,-0.6 0.3,1 6.8,4.3 7,5.9 0.2,1.2 -3.6,-1.3 -5.6,-1.6 1.2,1 2.8,2.5 1.9,3.5 -0.9,1 -4.2,1.4 -4.8,1.8 -8.6,5.5 12.2,6.8 19.7,2.7 7.5,-4 12.2,-9.9 12.4,-10.8 0.3,-0.9 2.7,-8.8 -13,-6.1 -9.9,1.8 -16.1,1.6 -23.9,-2.3 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path469-2"
+           d="m 262,303.1 c -9.1,5 -30.6,11.6 -36.7,11.9 37.5,-11.6 49.6,-27.3 55.8,-37.7 19.4,-3.8 54.8,-21.4 56.2,-41.9 -1.5,28 -24.6,47.4 -41.2,58.6 -19.6,13.3 -36.2,14.4 -50.3,23.4 4.3,-3 9.9,-6.9 16.2,-14.3 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path471-5"
+           d="m 347.2,126.4 c 11.7,38.1 -7.5,54.6 -15.6,59.7 10.3,-28.4 14,-63.7 2.8,-94.7 C 325.1,65.5 309,52.6 309,52.6 c 22.6,24.7 20,52 13.4,71.2 3.1,18.1 -7.3,68.4 5.7,66.1 -3.1,28.1 -15.2,62.6 -20.6,73.1 9,-14.2 21.9,-27.4 27.8,-38.5 11.2,-21.1 24.3,-62.6 11.9,-98.1 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path473-4"
+           d="m 301.3,135.3 c 0,0 -5,9.7 -4.6,28.6 -6.4,-24.7 -19.3,-34.6 -19.3,-34.6 1.7,19.9 5.2,48.8 -2.5,73.5 0.9,7.2 2.7,24.9 -4.2,44 11.3,-13 26.3,-23.5 28.5,-34 0,-0.3 0.1,-0.7 0.1,-1 3.8,0.7 9.1,-2.2 13.7,-6.8 3.8,-6.5 13.8,-25.9 14.7,-36.3 -23.7,-9.5 -26.4,-33.4 -26.4,-33.4 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path475-0"
+           d="m 297.1,200.1 c 30.8,-43.1 20.1,-88 16.8,-101.8 44.2,72.5 -1.1,156.7 -10.3,170.8 -2.5,2 -16.7,7.3 -22.5,7.9 1.9,-2.9 6.8,-13 6.2,-24.9 -6.7,16.4 -30.5,28.6 -43.7,33.1 22.8,-16.5 49,-62.5 53.5,-85.1 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path477-5"
+           d="m 291.9,167.7 c 0,0 2.5,37.5 -16.4,67.5 5.1,-28.3 -4.8,-46.1 -4.8,-46.1 0,0 -1.4,15.3 -7.4,30.1 -10.4,25.5 -19.8,30.7 -23.5,28 -8,31.7 -60.9,30.2 -60.9,30.2 12,3 54.1,5.3 85,-17.4 -1.7,4 -11.2,23.1 -34,32.9 22.5,-1.4 52.2,-25.2 57.5,-40.9 0.4,11.8 -3.4,20 -5.9,24.7 37.5,-42 10.4,-109 10.4,-109 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path479-9"
+           d="m 172.6,298.2 c 19.6,-1.8 35.6,-6.2 46.4,-20.4 -17.7,3 -31.7,1.7 -40.4,-0.3 0,0 13.9,0.6 31.5,-3.9 20.4,-5.1 45.7,-17 60.2,-44.3 -0.7,65 -66.6,77.9 -97.7,68.9 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path481-4"
+           d="M 46.7,52.2 C 46.3,51.6 46.3,53.6 45.9,53 43.2,48.2 41,40 40.7,34.2 c 0,0 -4.4,2.5 -7.2,11.5 -0.5,1.6 -0.9,2.5 -1.2,3.4 -0.1,0.3 0.2,-2.9 0.1,-2.6 -0.5,1.1 -2.1,2.9 -2.6,4.9 -0.4,1.6 -1,2.5 -1.3,4.5 C 28.4,56.5 28.4,53.5 28.3,54 21.3,71.6 22.1,97.3 23,96.2 39.6,74.6 60.5,67.7 60.5,67.7 58,66 52.6,61.7 46.7,52.2 Z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path483-6"
+           d="m 163.1,117.3 c 1.4,-1.1 6.3,-5.6 7.5,-10.9 -0.9,0.4 -1,-0.7 -2,-0.2 -1.8,1.9 -6.2,6.5 -11.4,9.8 1.4,-1.3 3.9,-3.2 4.5,-4.2 -5.6,3.9 -12.5,6.6 -17.9,6 -0.8,0 4,0.5 8.2,-2.8 -4.1,1.9 -11.1,1.7 -11.8,1.5 -0.6,-0.2 6.9,-1 6.2,-1.2 -3.5,-1.2 -8.1,-0.4 -9.1,0.1 -1.9,0.9 -3.8,2.2 -5.2,3.9 0.8,-1 1.1,-1.9 2,-3.4 -2.6,2.5 -6.2,5.2 -6.7,5.3 0.4,-0.8 6.3,-5.3 5.2,-4.9 -0.7,0.7 -3.2,2.1 -4.9,3.4 -0.5,0.3 3.5,-3.3 3.1,-3 -6.7,1.7 -6,5.4 -6.2,5.5 0.1,0.2 0.1,0.7 0.3,0.9 0.8,2.4 3.7,6.5 6.4,10.4 2,2.4 2.6,5.1 2.7,4.2 0.9,-4.4 27.2,-18.9 29.1,-20.4 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path485-9"
+           d="m 169.2,107.6 c -0.2,0 -0.4,-3.2 -0.1,-2.4 0.2,0.7 -0.3,7.2 -6.2,11 -1.3,0.8 -0.1,-2.1 -1.5,-0.6 -2.3,2.5 -8,10.8 -22.3,10.8 -0.5,0 5.6,-2.7 4.9,-2.5 -1.5,0.4 -3.2,0.9 -8.8,2.7 -0.5,0.2 4.7,-3.2 4.2,-3.1 -0.7,0.2 -3.8,2.3 -7.6,3.9 1.8,-1.8 3.9,-3.6 3.2,-3.3 -3,1.7 -5.2,3.6 -6.5,5.5 0.9,1.5 2,2.4 2.8,3.9 2,2.4 2.2,4.9 2.7,4.2 5.3,-6.4 26.2,-16.1 30.9,-21.1 4.8,-5.2 2.9,-4.4 4.3,-9 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path487-2"
+           d="M 138.2,252.4 C 111.3,244 80.6,231.6 78.2,196.3 75,150 117.6,155 117.6,155 c -1.5,0.6 -4.8,4 -5.9,7.9 -1.2,4.2 -3.4,12.4 6.2,20.9 15.2,13.4 -25,38.3 43.5,70.1 1.7,0.7 -15.3,1 -23.2,-1.5 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path489-2"
+           d="m 171.4,108.2 c 1.2,-3 2.6,-10 -1.4,-11.5 -3.3,-0.8 -6.2,-1.4 -11.6,-1.3 1.8,0.4 7,1.5 8.3,3.9 2.6,4.6 0.5,13.6 -0.4,15.9 2.7,-2.1 3.9,-4.1 5.1,-7 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path491-4"
+           d="m 127.5,229.9 c 18.8,4.5 40,1.3 52.1,-7 8.1,-5.6 19.8,-13.9 25.1,-13 -6,-1.7 -10.6,-2.4 -15.9,-2.1 -1,0 -1.9,0.1 -2.9,0.2 -1.8,0.2 -3.7,0.4 -5.8,0.8 -3.2,0.7 -6.7,3.1 -10,3.1 -0.2,0 3.1,-1.7 2.8,-1.7 -1.7,0.5 -3.6,0.8 -5.6,1.3 -1.2,0.3 -2.4,0.5 -3.6,0.7 -37.7,7 -72.2,-13.5 -72.2,-13.5 -1.9,9.5 14.9,26.2 36,31.2 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path493-7"
+           d="m 289.2,78.5 c 0,0 14.4,15.5 21.2,30.3 6.8,14.8 8.9,31.6 8.9,31.6 0,0 1,-14.1 -6.8,-37.8 -8.4,-25.7 -25,-47.7 -41.4,-59.8 -11,-8.3 -33.1,-19.3 -33.1,-19.3 0,0 38.1,22.6 51.2,55 z" />
+        <path
+           style="opacity:0.1;fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path495-7"
+           d="m 81.2,75.2 c 0.2,0 -7.1,0.9 -20,12.2 -5.5,4.5 -9.9,8.9 -13.3,12.7 -9.4,11.4 -14.9,22.4 -14.9,22.4 0,0 0.8,-6.8 5.1,-16.2 -13.7,21.6 -18.9,53 -18.9,53 0,0 -0.8,-14.3 2.8,-31.1 -1.4,3.9 -3.1,9.4 -4,16.7 -2.7,22 0,41.3 0,41.3 0,0 -1.2,-4.2 -2.5,-10.2 0.5,4.4 1.2,9.6 2.4,15.5 4.3,20.8 12.4,40.5 12.4,40.5 0,0 -10,-13.5 -16.6,-34.1 1.2,6.3 3.1,14.1 5.7,23.5 8.2,28.5 19.1,43.3 19.1,43.3 0,0 -8.4,-7.4 -19.3,-34.9 C 14.4,217.6 11.9,206 10.3,197.4 9.4,191.1 8.6,185.3 7.8,176.9 7.5,174 7.1,170.6 7.1,167.8 c -2.4,11.4 -3.9,21.1 -3.9,21.1 0,0 0.6,-22.8 4.3,-43.4 0.6,-3.1 1.3,-6 2.2,-8.8 -3.5,6.7 -6.2,12.3 -6.2,12.3 0,0 4.6,-12.8 9,-23.5 -4.4,7.9 -7,14.4 -7,14.4 0,0 7.7,-26.4 16.9,-39.7 5,-7.2 10,-12.1 13.6,-15.1 1.2,-1.2 2.4,-2.3 3.7,-3.2 1.3,-1 2.7,-2 3.9,-2.9 0.6,-0.5 1.3,-1 2,-1.5 12.4,-9.2 25.7,-11.4 30.2,-10.9 0.1,0 -3.9,0.2 -12.5,4.8 4.2,-1.5 7.6,-2 9.6,-1.9 0.1,0 -3,0.7 -10.1,5.3 9.2,-4.5 17.6,-5.7 21,-5.3 0.2,0 -6.5,0.4 -20.5,9.5 -0.4,0.3 -0.8,0.5 -1.2,0.8 8.4,-3.7 16,-4.7 19.1,-4.6 z m -39.4,79 c -2.5,1.2 -5.4,10.8 -3.1,32.5 1.9,17.7 9.3,27.1 9.3,27.1 0,0 -3.8,-7.1 -6.1,-31.5 -2,-21 -0.3,-27.8 -0.1,-28.1 z m 6.9,-16.7 c -3.4,17.8 1.2,42.9 1.2,42.9 0,0 -0.8,-21.1 3.8,-43 4.8,-23.4 12,-30.3 12.1,-30.1 -3.9,0.4 -13.7,12.4 -17.1,30.2 z m 9.2,-44.8 c -2.1,2.2 -3.9,4.6 -5.4,7.1 -5.6,5.5 -12,16.4 -15.2,31.5 -6,29.3 -1.7,47 -1.7,47 0,0 -0.1,-27.1 6.3,-50.3 0.9,-3.3 1.8,-6.3 2.8,-9 -1.6,6.6 -2,11.5 -2,11.5 0,0 5.2,-21.4 23.6,-39.7 C 77.9,79.2 85.8,76.9 85.9,77 c -8.6,1 -19.4,6.5 -28,15.7 z m -6.7,62.8 c -1.2,13 1.1,26.4 1.1,26.4 0,0 -0.2,-13.5 1.5,-28.7 1.7,-15.1 4,-20.9 4.1,-20.8 -2.8,1.5 -5.8,13.7 -6.7,23.1 z m 1.4,-44.1 c -5.9,10.2 -7.9,20.3 -7.9,20.3 0,0 7.4,-16.8 12.5,-24.1 5.1,-7.3 10.1,-12.1 10.1,-12 -3.1,1.3 -9.7,5.9 -14.7,15.8 z m -26.3,37.8 c -2.5,1 -6.1,10.5 -5.1,32.3 0.8,17.7 7.6,27.6 7.6,27.6 0,0 -3.3,-7.3 -4.1,-31.8 m 105.4,-128 c 0,0 -12.1,4.4 -18.9,13.1 -6.8,8.7 -8.1,17.7 -8.1,17.7 0,0 7.5,-20 27,-30.8 z m -8.5,11.1 c -8.7,11.5 -10.8,19.8 -10.8,19.8 0,0 9.7,-22.9 34.1,-32.7 0,0.1 -14.6,1.5 -23.3,12.9 z M 34.1,58.5 c 1.5,-13.4 5.3,-21.3 5.3,-21.3 0,0 -12.5,18.9 -5,42 0,0.1 -1.8,-7.3 -0.3,-20.7 z m 9.4,16.1 c 0,0 -2.8,-6.2 -3.9,-17.6 -1.1,-11.5 0.8,-18.5 0.8,-18.5 0,0 -7.5,17 3.1,36.1 z" />
+        <path
+           style="opacity:0.5;fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path497-5"
+           d="m 208.4,198.6 c -1.8,-2.4 -9.6,-8.1 -18.3,-8.7 -11.6,-0.8 -21,4.2 -21,4.2 0,0 6.4,-3.7 21.2,-2.4 10.2,0.9 18,6.6 18.1,6.9 z" />
+        <path
+           style="opacity:0.5;fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path499-4"
+           d="m 212.3,203.2 c -1.8,-2.5 -8.4,-8.3 -19,-10.4 -13.5,-2.6 -23.4,3.1 -23.4,3.1 0,0 7.7,-3.2 23.3,-0.7 10.7,1.8 18.9,7.8 19.1,8 z" />
+        <path
+           style="opacity:0.5;fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path501-8"
+           d="m 208.5,203.3 c -1.5,-1.4 -4.9,-3.8 -10.8,-5.5 -9.5,-2.7 -15.9,-0.2 -15.9,-0.2 0,0 3.8,-0.9 13.5,1 6,1.2 13.1,4.6 13.2,4.7 z" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path503-1"
+           d="m 330.5,259 c -1.9,3.6 -4.4,7.5 -7.7,11.5 -8.1,10 -18.3,17.9 -26.7,23.6 -3.4,2.3 -6.7,4.3 -10,6 l -0.1,-1.2 -0.1,0 c 9.7,-5.1 20.2,-12 31,-22.6 6.4,-6.3 10.7,-12 13.6,-17.3 z M 33.1,47.6 c 0.4,-0.9 0.7,-1.8 1.2,-3.4 0.6,-1.8 1.2,-3.4 1.9,-4.7 -0.9,1.6 -1.9,3.6 -2.7,6.2 -0.2,0.5 -0.3,0.9 -0.4,1.3 z m 104.3,285.5 c 0,0 1.4,1.3 3.8,2.9 9.2,2.6 30.1,7.9 46.5,7.3 -2,-0.4 -3.6,-0.9 -4.7,-1.5 -20.8,-0.7 -45.6,-8.7 -45.6,-8.7 z M 9.6,138.4 c -0.5,0.8 -0.9,1.7 -1.4,2.5 0.1,-0.1 0.1,-0.2 0.2,-0.3 -4.2,13 -7.4,33.1 -5.4,63 0,-0.2 0.1,-0.6 0.1,-1.2 0,0.4 0,0.7 0.1,1.1 0,-0.4 0.2,-2.1 0.6,-4.7 -1.5,-28.6 1.7,-47.9 5.8,-60.4 z M 28.8,254.7 C 13.1,227.8 8.3,203 7.2,182.9 7,184 6.7,185.1 6.5,186.1 c 1.3,19.8 6.2,44 21.5,70 12,20.5 43.5,68.1 122.6,85.9 -3.6,-1 -6.7,-2.5 -9,-3.9 C 69.7,318.9 40.3,274.4 28.8,254.7 Z m 253.9,51.8 c 0.3,-0.3 0.8,-0.9 0.9,-0.9 -26.5,36.2 -103.2,31.8 -103.2,31.8 0,0 0.3,0.7 1.3,1.6 10.9,0.3 62.8,0.7 91.3,-21.8 7.1,-5.3 11.7,-11.5 13.2,-17.1 0,0 -0.1,0.1 -0.4,0.2 -0.7,2.4 -2,4.6 -3.1,6.2 z M 16.8,105.9 C 11,115.8 4.9,132.1 0,159.4 c 0,0 0.1,-0.4 0.4,-1.1 -0.1,0.3 -0.1,0.7 -0.2,1 0,0 0.4,-1.1 1.1,-3.1 4.2,-23.3 9.4,-38.4 14.5,-48.3 0.2,-0.5 0.6,-1.2 1,-2 z M 29.4,54.2 c 0.2,-1.9 0.9,-2.8 1.2,-4.3 0.1,-0.4 0.3,-0.9 0.5,-1.3 -0.5,0.8 -1,1.7 -1.2,2.7 -0.2,0.6 -0.4,1.2 -0.6,1.7 0,0.4 0,1 0.1,1.2 -0.1,0.1 0,0.1 0,0 z m -5.5,40.4 c 0,-0.9 -0.1,-1.8 -0.1,-2.7 -0.8,-11.9 0.6,-21.2 1.9,-28 0.8,-3.5 1.7,-6.7 2.7,-9.6 0,-0.2 0,-0.4 -0.1,-0.4 l -0.1,0 c -0.2,0.5 -0.4,1.1 -0.6,1.6 0,0.1 -0.1,0.2 -0.1,0.3 -0.1,0.3 -0.2,0.5 -0.3,0.8 -0.3,0.9 -0.6,1.8 -0.9,2.8 -0.4,1.5 -0.8,3 -1.2,4.6 0,0.2 -0.1,0.4 -0.1,0.6 -0.1,0.2 -0.1,0.5 -0.2,0.7 0,0.1 0,0.2 -0.1,0.4 -0.7,3.1 -1.2,6.5 -1.6,10.2 -1.2,10.2 -0.9,18.8 -0.4,20.1 0.5,-0.5 0.8,-0.9 1.2,-1.4 z M 286,298.9 c -0.6,0.3 -5.6,2.9 -13.8,6.3 -15.4,6.4 -26,11.3 -26.9,13 0,0 4,-2.7 17.7,-8.2 14.3,-5.7 21.1,-9 22.8,-9.8 0.3,-0.1 0.4,-0.2 0.4,-0.2 z" />
+        <path
+           style="opacity:0.1;fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path505-2"
+           d="m 154.4,321.9 c 0,0 -0.1,0 0,0 m 0,-0.9 c 1,2.5 10.5,6.1 32.3,5.1 17.7,-0.8 27.6,-7.6 27.6,-7.6 0,0 -7.3,3.3 -31.8,4.2 -21.2,0.6 -27.8,-1.5 -28.1,-1.7 z M 141,314.1 c 17.7,3.9 39.7,0.5 39.7,0.5 0,0 -21.1,0.2 -42.9,-5 -23.3,-5.5 -29.9,-12.9 -29.8,-13 0.4,4 15.3,13.6 33,17.5 z m 14.9,-1.5 c 12.9,1.6 26.4,-0.3 26.4,-0.3 0,0 -13.5,-0.2 -28.7,-2.3 -15,-2.1 -20.7,-4.5 -20.7,-4.7 1.5,2.8 13.6,6.1 23,7.3 z m -43.8,-2.5 c 10.5,5.2 20.7,6.6 20.7,6.6 0,0 -17.2,-6.3 -24.9,-10.9 -7.6,-4.6 -13.8,-8.6 -14,-9 1.7,3 8.1,8.9 18.2,13.3 z m 36.8,27.2" />
+        <path
+           style="fill:#000000;fill-opacity:0.00478468"
+           inkscape:connector-curvature="0"
+           id="path507-8"
+           d="m 100.9,67 c 0,0 -2.7,3.2 -4.7,6.4 -2.3,3.5 -4.2,7.2 -4.2,7.2 0,0 -11.4,-8.4 -21.6,-10.1 -10.2,-1.7 -13.2,-1.4 -13.2,-1.4 0,0 17,-8.8 43.7,-2.1 z" />
+      </g>
+      <g
+         style="fill:#000025;fill-opacity:0.01568627;filter:url(#filter6644);enable-background:new"
+         transform="matrix(1.3000209,0,0,1.300021,2.5931149,33.72954)"
+         id="g4815-3">
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path427-9"
+           d="M 46.8,52.2 C 46.4,51.6 46.4,53.7 46,53 43.3,48.2 41.1,40 40.8,34.2 c 0,0 -4.4,2.5 -7.2,11.5 -0.5,1.6 -0.9,2.5 -1.2,3.4 -0.1,0.3 0.2,-2.9 0.1,-2.6 -0.5,1.1 -2.1,2.9 -2.6,4.9 -0.4,1.6 -1,2.5 -1.3,4.5 -0.1,0.6 -0.1,-2.4 -0.2,-1.9 -3.7,9.8 -6.7,23.6 -5,42.3 C 40.1,81.3 63.8,70 63.8,70 61.1,68.3 52.7,61.7 46.8,52.2 Z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path429-2"
+           d="m 3,203.5 c 0.2,-2.8 7,-59.4 33.2,-78.5 22.6,-16.5 5,-10.5 -3.7,-9.8 -9.2,0.7 -14.1,6.3 -12.3,4.3 0.1,-0.1 0.1,-0.1 0.1,-0.2 C 20,118.9 -1.3,136.8 3,203.5 Z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path431-83"
+           d="m 0,159.3 c 0,0 15.4,-49 46.6,-48.5 20.7,0.3 4.3,-17.5 -2,-20.2 -6.5,-2.8 -8.1,-2.7 -9.6,-1.3 -2.3,2 -22.8,1.2 -35,70 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path433-0"
+           d="m 285.7,35.9 c 0,0 14.7,7.1 24.2,22.3 7.8,12.4 4.1,29.1 -2.9,26.2 -6.9,-2.9 -21.3,-48.5 -21.3,-48.5 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path435-1"
+           d="m 311,86 c 4.1,-31.5 -25.4,-50.2 -25.4,-50.2 0,0 1.9,10.8 4.2,34.8 2.8,27.5 19.3,30.2 21.2,15.4 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path437-7"
+           d="m 212.2,329.1 c 53.3,11.3 93.6,-33.7 64.8,-44.5 -26.1,-9.8 -90.1,39.1 -64.8,44.5 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path439-8"
+           d="m 281.7,286 c 53.2,-11.6 71.4,-69.2 40.8,-67.2 -27.8,1.8 -66,72.7 -40.8,67.2 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path441-9"
+           d="m 328.9,196.4 c 34.9,-25.2 18.3,-70 18.3,-70 0,0 -7.7,23.1 -14.7,50.3 -6.9,27.1 -24.5,34.8 -3.6,19.7 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path443-1"
+           d="m 339.3,118.1 c -3.7,-43.2 -30.5,-65.6 -30.5,-65.6 0,0 2.7,14.7 6.3,34.8 4.8,27.5 26.4,56.5 24.2,30.8 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path451-5"
+           d="m 177.6,205.1 c -1,1 0.1,3.9 1.4,3.8 1.3,-0.1 3.2,-0.7 3.2,-0.7 0,0 1,1.9 0,2.5 -1,0.5 -3.8,0.3 -0.1,1.7 3.8,1.4 4.8,1 5,0.3 0.3,-0.7 1.5,-3.1 2.2,-2.9 0.6,-1.2 -2,-2.4 -0.6,-3.2 1.4,-0.8 0.3,-3.9 0.3,-3.9 0,0 -2,0.1 -2.8,1.5 -0.8,1.4 -2,-0.1 -2.8,-0.1 -0.1,0.8 -0.7,1.5 -0.7,1.5 l -0.6,-1.3 c 0.1,-0.1 -3.8,-0.2 -4.5,0.8 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path459-4"
+           d="m 303.4,269.6 c 9.7,-18.2 22.8,-28.9 29.9,-41.5 9.4,-16.8 27.3,-63.9 13.8,-102 6.2,23.8 4.2,48 -15.4,60.2 6.4,-16.8 10.3,-53.6 3.8,-86.8 -4.3,-21.6 -17.8,-40.9 -26.5,-46.9 8.1,6.1 14.6,27.8 14.4,37.8 C 306.5,61.9 278.8,34.6 237,23.1 269.5,44.5 281.6,62.7 289.2,78.9 280.5,70 265.7,60.8 255.6,60 c 15,11.2 40.2,44.4 37.5,94.7 -3.9,-8.1 -10.9,-20.8 -15.9,-25.2 5.4,49.4 0.7,60 -2.6,73.1 -0.7,-6 -2.9,-10.6 -4.1,-13.3 0,0 -0.6,15.4 -10.6,37.4 -7.6,16.7 -15.4,21.8 -18.9,21.2 -0.9,-0.1 -1.4,-0.5 -1.4,-0.5 0.2,-2.2 0.5,-4.4 -0.1,-5.9 0,0 -3.2,1.1 -5.3,4 -0.8,1.2 -1.9,2.3 -3.3,3.4 -0.2,0.2 2.3,-3.2 2.1,-3.1 -1.2,1 -2.6,2.2 -3.9,3.6 -4.9,5.1 -9.4,10.8 -11.7,9.2 2.1,-0.7 3.9,-3.4 4.3,-6.1 -1.9,1.4 -6.8,5 -17.8,6.7 -4.5,0.7 -23.6,4.2 -49.1,-8.6 3.7,-0.4 9.3,-1.7 13.5,0.8 -4.2,-4.6 -14.5,-3.7 -21.8,-6 -6.4,-2 -14.7,-11 -19.5,-15.5 19.6,4.8 40.4,1.3 52.4,-6.9 12.2,-8.3 19.4,-14.4 25.8,-12.9 6.4,1.4 10.7,-5 5.7,-10.8 -5,-5.8 -17.2,-13.5 -33.7,-9.4 -12.7,3.2 -23.4,13.3 -41.2,6.3 -1.1,-0.4 -2.2,-0.9 -3.3,-1.5 -1.1,-0.6 3.7,0.7 2.5,0 -3.4,-1.3 -9.6,-4.1 -11.2,-5.2 -0.3,-0.2 2.6,0.5 2.3,0.3 -16.9,-10 -15.8,-18 -15.8,-22.9 0,-4 2.4,-9.3 6.9,-11.8 2.4,0.9 3.9,1.7 3.9,1.7 0,0 -1.1,-1.7 -1.8,-2.6 0.2,-0.1 0.3,-0.1 0.5,-0.2 2,0.7 6.5,2.3 8.7,3.5 3.1,1.5 4.1,3.1 4.1,3.1 0,0 0.7,-0.5 0,-2 -0.3,-0.7 -1.4,-2.6 -4.4,-4.4 l 0.1,0 c 1.6,0.6 3.3,1.4 5.1,2.5 0.6,-2.7 1.7,-5.5 1,-10.4 -0.6,-3.5 -0.5,-4.3 -1.3,-5.6 -0.7,-1.1 0.2,-1.5 1.3,-0.6 -0.3,-0.9 -0.7,-1.7 -1.1,-2.6 0.9,-4.3 26.3,-17.6 28.2,-19 2.6,-1.9 5.3,-4.9 7,-8.4 1.2,-2.2 2.1,-5.3 1.9,-9.9 -0.2,-3.3 -2.1,-5.3 -29.2,-5 -7.4,0.1 -12.2,-4.2 -15.1,-8.3 -0.6,-0.9 -1.1,-1.7 -1.6,-2.5 -0.6,-1.1 -1.1,-2.2 -1.4,-3 3.2,-11.7 9.7,-21.9 19.8,-30.2 0.6,-0.5 -2.4,0.3 -1.8,-0.2 0.7,-0.6 5,-2.7 5.8,-3.1 1,-0.6 -4.7,-2.1 -9.5,-1.1 -4.9,1 -5.8,1.6 -8.4,2.9 1,-1.1 4.3,-2.7 3.5,-2.6 -5.3,1.2 -11.6,4.7 -16.9,8.4 0,-0.5 0,-0.9 0.1,-1.6 -2.5,1.3 -8.6,6 -10.1,9.5 0,-0.8 0,-1.2 -0.1,-2 -1.7,1.6 -3.4,3.5 -4.9,5.5 0,0 0,0.1 -0.1,0.1 C 84.9,63.1 71.5,64 60.2,67.6 57.5,65.7 53.2,62.7 46.4,52.2 46,51.6 46,53.6 45.6,53 42.9,48.2 40.7,40 40.4,34.2 c 0,0 -4.4,2.5 -7.2,11.5 -0.5,1.6 -0.9,2.5 -1.2,3.4 -0.1,0.3 0.2,-2.9 0.1,-2.6 -0.5,1.1 -2.1,2.9 -2.6,4.9 -0.4,1.5 -1,2.4 -1.2,4.3 0,0 0,0.1 -0.1,0.1 0,-0.5 -0.1,-2.2 -0.2,-1.9 -1.3,3.3 -2.4,7.1 -3.4,11.4 -1.4,6.8 -2.8,16.1 -1.9,27.9 0,1 0.1,1.9 0.1,2.7 -4.3,5.9 -7,10.9 -8.1,13.4 -5.2,10.1 -10.5,25.7 -14.8,49.9 0,0 2.9,-9.1 8.6,-19.4 -4.2,13 -7.6,33.2 -5.6,63.5 0.1,-1 1,-8.7 3.2,-19 1.1,20.2 5.9,44.9 21.6,71.8 12,20.5 43.5,68.1 122.6,85.9 -8.7,-2.5 -14.1,-7.5 -14.1,-7.5 0,0 29.6,9.5 51.1,8.7 -6.8,-1.2 -8.1,-4.4 -8.1,-4.4 0,0 76.7,4.3 103.2,-31.8 -9.1,10.6 -32,13.6 -40.7,13.7 13.2,-12.1 42.4,-11.9 74.1,-43 17.4,-17.1 19.2,-30.1 21.1,-42.2 -2.5,15.8 -17.7,25.4 -33.5,34.1 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path461-9"
+           d="m 303.4,269.6 c 9.7,-18.2 22.8,-28.9 29.9,-41.5 9.4,-16.8 27.3,-63.9 13.8,-102 6.2,23.8 4.2,48 -15.4,60.2 6.4,-16.8 10.3,-53.6 3.8,-86.8 -4.3,-21.6 -17.8,-40.9 -26.5,-46.9 8.1,6.1 14.6,27.8 14.4,37.8 C 306.5,61.9 278.8,34.6 237,23.1 269.5,44.5 281.6,62.7 289.2,78.9 280.5,70 265.7,60.8 255.6,60 c 15,11.2 40.2,44.4 37.5,94.7 -3.9,-8.1 -10.9,-20.8 -15.9,-25.2 5.4,49.4 0.7,60 -2.6,73.1 -0.7,-6 -2.9,-10.6 -4.1,-13.3 0,0 -0.6,15.4 -10.6,37.4 -7.6,16.7 -15.4,21.8 -18.9,21.2 -0.9,-0.1 -1.4,-0.5 -1.4,-0.5 0.2,-2.2 0.5,-4.4 -0.1,-5.9 0,0 -3.2,1.1 -5.3,4 -0.8,1.2 -1.9,2.3 -3.3,3.4 -0.2,0.2 2.3,-3.2 2.1,-3.1 -1.2,1 -2.6,2.2 -3.9,3.6 -4.9,5.1 -9.4,10.8 -11.7,9.2 2.1,-0.7 3.9,-3.4 4.3,-6.1 -1.9,1.4 -6.8,5 -17.8,6.7 -4.5,0.7 -23.6,4.2 -49.1,-8.6 3.7,-0.4 9.3,-1.7 13.5,0.8 -4.2,-4.6 -14.5,-3.7 -21.8,-6 -6.4,-2 -14.7,-11 -19.5,-15.5 19.6,4.8 40.4,1.3 52.4,-6.9 12.2,-8.3 19.4,-14.4 25.8,-12.9 6.4,1.4 10.7,-5 5.7,-10.8 -5,-5.8 -17.2,-13.5 -33.7,-9.4 -12.7,3.2 -23.4,13.3 -41.2,6.3 -1.1,-0.4 -2.2,-0.9 -3.3,-1.5 -1.1,-0.6 3.7,0.7 2.5,0 -3.4,-1.3 -9.6,-4.1 -11.2,-5.2 -0.3,-0.2 2.6,0.5 2.3,0.3 -16.9,-10 -15.8,-18 -15.8,-22.9 0,-4 2.4,-9.3 6.9,-11.8 2.4,0.9 3.9,1.7 3.9,1.7 0,0 -1.1,-1.7 -1.8,-2.6 0.2,-0.1 0.3,-0.1 0.5,-0.2 2,0.7 6.5,2.3 8.7,3.5 3.1,1.5 4.1,3.1 4.1,3.1 0,0 0.7,-0.5 0,-2 -0.3,-0.7 -1.4,-2.6 -4.4,-4.4 l 0.1,0 c 1.6,0.6 3.3,1.4 5.1,2.5 0.6,-2.7 1.7,-5.5 1,-10.4 -0.6,-3.5 -0.5,-4.3 -1.3,-5.6 -0.7,-1.1 0.2,-1.5 1.3,-0.6 -0.3,-0.9 -0.7,-1.7 -1.1,-2.6 0.9,-4.3 26.3,-17.6 28.2,-19 2.6,-1.9 5.3,-4.9 7,-8.4 1.2,-2.2 2.1,-5.3 1.9,-9.9 -0.2,-3.3 -2.1,-5.3 -29.2,-5 -7.4,0.1 -12.2,-4.2 -15.1,-8.3 -0.6,-0.9 -1.1,-1.7 -1.6,-2.5 -0.6,-1.1 -1.1,-2.2 -1.4,-3 3.2,-11.7 9.7,-21.9 19.8,-30.2 0.6,-0.5 -2.4,0.3 -1.8,-0.2 0.7,-0.6 5,-2.7 5.8,-3.1 1,-0.6 -4.7,-2.1 -9.5,-1.1 -4.9,1 -5.8,1.6 -8.4,2.9 1,-1.1 4.3,-2.7 3.5,-2.6 -5.3,1.2 -11.6,4.7 -16.9,8.4 0,-0.5 0,-0.9 0.1,-1.6 -2.5,1.3 -8.6,6 -10.1,9.5 0,-0.8 0,-1.2 -0.1,-2 -1.7,1.6 -3.4,3.5 -4.9,5.5 0,0 0,0.1 -0.1,0.1 C 84.9,63.1 71.5,64 60.2,67.6 57.5,65.7 53.2,62.7 46.4,52.2 46,51.6 46,53.6 45.6,53 42.9,48.2 40.7,40 40.4,34.2 c 0,0 -4.4,2.5 -7.2,11.5 -0.5,1.6 -0.9,2.5 -1.2,3.4 -0.1,0.3 0.2,-2.9 0.1,-2.6 -0.5,1.1 -2.1,2.9 -2.6,4.9 -0.4,1.5 -1,2.4 -1.2,4.3 0,0 0,0.1 -0.1,0.1 0,-0.5 -0.1,-2.2 -0.2,-1.9 -1.3,3.3 -2.4,7.1 -3.4,11.4 -1.4,6.8 -2.8,16.1 -1.9,27.9 0,1 0.1,1.9 0.1,2.7 -4.3,5.9 -7,10.9 -8.1,13.4 -5.2,10.1 -10.5,25.7 -14.8,49.9 0,0 2.9,-9.1 8.6,-19.4 -4.2,13 -7.6,33.2 -5.6,63.5 0.1,-1 1,-8.7 3.2,-19 1.1,20.2 5.9,44.9 21.6,71.8 12,20.5 43.5,68.1 122.6,85.9 -8.7,-2.5 -14.1,-7.5 -14.1,-7.5 0,0 29.6,9.5 51.1,8.7 -6.8,-1.2 -8.1,-4.4 -8.1,-4.4 0,0 76.7,4.3 103.2,-31.8 -9.1,10.6 -32,13.6 -40.7,13.7 13.2,-12.1 42.4,-11.9 74.1,-43 17.4,-17.1 19.2,-30.1 21.1,-42.2 -2.5,15.8 -17.7,25.4 -33.5,34.1 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path463-2"
+           d="m 303.4,269.6 c 9.7,-18.2 22.8,-28.9 29.9,-41.5 9.4,-16.8 27.3,-63.9 13.8,-102 6.2,23.8 4.2,48 -15.4,60.2 6.4,-16.8 10.3,-53.6 3.8,-86.8 -4.3,-21.6 -17.8,-40.9 -26.5,-46.9 8.1,6.1 14.6,27.8 14.4,37.8 C 306.5,61.9 278.8,34.6 237,23.1 269.5,44.5 281.6,62.7 289.2,78.9 280.5,70 265.7,60.8 255.6,60 c 15,11.2 40.2,44.4 37.5,94.7 -3.9,-8.1 -10.9,-20.8 -15.9,-25.2 5.4,49.4 0.7,60 -2.6,73.1 -0.7,-6 -2.9,-10.6 -4.1,-13.3 0,0 -0.6,15.4 -10.6,37.4 -7.6,16.7 -15.4,21.8 -18.9,21.2 -0.9,-0.1 -1.4,-0.5 -1.4,-0.5 0.2,-2.2 0.5,-4.4 -0.1,-5.9 0,0 -3.2,1.1 -5.3,4 -0.8,1.2 -1.9,2.3 -3.3,3.4 -0.2,0.2 2.3,-3.2 2.1,-3.1 -1.2,1 -2.6,2.2 -3.9,3.6 -4.9,5.1 -9.4,10.8 -11.7,9.2 2.1,-0.7 3.9,-3.4 4.3,-6.1 -1.9,1.4 -6.8,5 -17.8,6.7 -4.5,0.7 -23.6,4.2 -49.1,-8.6 3.7,-0.4 9.3,-1.7 13.5,0.8 -4.2,-4.6 -14.5,-3.7 -21.8,-6 -6.4,-2 -14.7,-11 -19.5,-15.5 19.6,4.8 40.4,1.3 52.4,-6.9 12.2,-8.3 19.4,-14.4 25.8,-12.9 6.4,1.4 10.7,-5 5.7,-10.8 -5,-5.8 -17.2,-13.5 -33.7,-9.4 -12.7,3.2 -23.4,13.3 -41.2,6.3 -1.1,-0.4 -2.2,-0.9 -3.3,-1.5 -1.1,-0.6 3.7,0.7 2.5,0 -3.4,-1.3 -9.6,-4.1 -11.2,-5.2 -0.3,-0.2 2.6,0.5 2.3,0.3 -16.9,-10 -15.8,-18 -15.8,-22.9 0,-4 2.4,-9.3 6.9,-11.8 2.4,0.9 3.9,1.7 3.9,1.7 0,0 -1.1,-1.7 -1.8,-2.6 0.2,-0.1 0.3,-0.1 0.5,-0.2 2,0.7 6.5,2.3 8.7,3.5 3.1,1.5 4.1,3.1 4.1,3.1 0,0 0.7,-0.5 0,-2 -0.3,-0.7 -1.4,-2.6 -4.4,-4.4 l 0.1,0 c 1.6,0.6 3.3,1.4 5.1,2.5 0.6,-2.7 1.7,-5.5 1,-10.4 -0.6,-3.5 -0.5,-4.3 -1.3,-5.6 -0.7,-1.1 0.2,-1.5 1.3,-0.6 -0.3,-0.9 -0.7,-1.7 -1.1,-2.6 0.9,-4.3 26.3,-17.6 28.2,-19 2.6,-1.9 5.3,-4.9 7,-8.4 1.2,-2.2 2.1,-5.3 1.9,-9.9 -0.2,-3.3 -2.1,-5.3 -29.2,-5 -7.4,0.1 -12.2,-4.2 -15.1,-8.3 -0.6,-0.9 -1.1,-1.7 -1.6,-2.5 -0.6,-1.1 -1.1,-2.2 -1.4,-3 3.2,-11.7 9.7,-21.9 19.8,-30.2 0.6,-0.5 -2.4,0.3 -1.8,-0.2 0.7,-0.6 5,-2.7 5.8,-3.1 1,-0.6 -4.7,-2.1 -9.5,-1.1 -4.9,1 -5.8,1.6 -8.4,2.9 1,-1.1 4.3,-2.7 3.5,-2.6 -5.3,1.2 -11.6,4.7 -16.9,8.4 0,-0.5 0,-0.9 0.1,-1.6 -2.5,1.3 -8.6,6 -10.1,9.5 0,-0.8 0,-1.2 -0.1,-2 -1.7,1.6 -3.4,3.5 -4.9,5.5 0,0 0,0.1 -0.1,0.1 C 84.9,63.1 71.5,64 60.2,67.6 57.5,65.7 53.2,62.7 46.4,52.2 46,51.6 46,53.6 45.6,53 42.9,48.2 40.7,40 40.4,34.2 c 0,0 -4.4,2.5 -7.2,11.5 -0.5,1.6 -0.9,2.5 -1.2,3.4 -0.1,0.3 0.2,-2.9 0.1,-2.6 -0.5,1.1 -2.1,2.9 -2.6,4.9 -0.4,1.5 -1,2.4 -1.2,4.3 0,0 0,0.1 -0.1,0.1 0,-0.5 -0.1,-2.2 -0.2,-1.9 -1.3,3.3 -2.4,7.1 -3.4,11.4 -1.4,6.8 -2.8,16.1 -1.9,27.9 0,1 0.1,1.9 0.1,2.7 -4.3,5.9 -7,10.9 -8.1,13.4 -5.2,10.1 -10.5,25.7 -14.8,49.9 0,0 2.9,-9.1 8.6,-19.4 -4.2,13 -7.6,33.2 -5.6,63.5 0.1,-1 1,-8.7 3.2,-19 1.1,20.2 5.9,44.9 21.6,71.8 12,20.5 43.5,68.1 122.6,85.9 -8.7,-2.5 -14.1,-7.5 -14.1,-7.5 0,0 29.6,9.5 51.1,8.7 -6.8,-1.2 -8.1,-4.4 -8.1,-4.4 0,0 76.7,4.3 103.2,-31.8 -9.1,10.6 -32,13.6 -40.7,13.7 13.2,-12.1 42.4,-11.9 74.1,-43 17.4,-17.1 19.2,-30.1 21.1,-42.2 -2.5,15.8 -17.7,25.4 -33.5,34.1 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path465-5"
+           d="m 171,100.4 c -0.2,-3.3 -2.3,-5.6 -29.4,-5.4 -11.1,0.1 -16.3,-9.6 -18.1,-13.7 -2.9,10.5 -3.4,21.3 -1.2,34 1.4,8.4 7.4,15.5 10.7,20.5 0.8,0.8 1.2,1 1.4,0.5 1.2,-2.6 25,-16.1 26.9,-17.6 2,-1.3 10.2,-8.3 9.7,-18.3 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path467-7"
+           d="m 133.9,97.3 c 0,0 9.4,4.6 10.8,7.5 0.4,0.9 -4.8,-1.6 -4.5,-0.6 0.3,1 6.8,4.3 7,5.9 0.2,1.2 -3.6,-1.3 -5.6,-1.6 1.2,1 2.8,2.5 1.9,3.5 -0.9,1 -4.2,1.4 -4.8,1.8 -8.6,5.5 12.2,6.8 19.7,2.7 7.5,-4 12.2,-9.9 12.4,-10.8 0.3,-0.9 2.7,-8.8 -13,-6.1 -9.9,1.8 -16.1,1.6 -23.9,-2.3 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path469-4"
+           d="m 262,303.1 c -9.1,5 -30.6,11.6 -36.7,11.9 37.5,-11.6 49.6,-27.3 55.8,-37.7 19.4,-3.8 54.8,-21.4 56.2,-41.9 -1.5,28 -24.6,47.4 -41.2,58.6 -19.6,13.3 -36.2,14.4 -50.3,23.4 4.3,-3 9.9,-6.9 16.2,-14.3 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path471-9"
+           d="m 347.2,126.4 c 11.7,38.1 -7.5,54.6 -15.6,59.7 10.3,-28.4 14,-63.7 2.8,-94.7 C 325.1,65.5 309,52.6 309,52.6 c 22.6,24.7 20,52 13.4,71.2 3.1,18.1 -7.3,68.4 5.7,66.1 -3.1,28.1 -15.2,62.6 -20.6,73.1 9,-14.2 21.9,-27.4 27.8,-38.5 11.2,-21.1 24.3,-62.6 11.9,-98.1 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path473-9"
+           d="m 301.3,135.3 c 0,0 -5,9.7 -4.6,28.6 -6.4,-24.7 -19.3,-34.6 -19.3,-34.6 1.7,19.9 5.2,48.8 -2.5,73.5 0.9,7.2 2.7,24.9 -4.2,44 11.3,-13 26.3,-23.5 28.5,-34 0,-0.3 0.1,-0.7 0.1,-1 3.8,0.7 9.1,-2.2 13.7,-6.8 3.8,-6.5 13.8,-25.9 14.7,-36.3 -23.7,-9.5 -26.4,-33.4 -26.4,-33.4 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path475-4"
+           d="m 297.1,200.1 c 30.8,-43.1 20.1,-88 16.8,-101.8 44.2,72.5 -1.1,156.7 -10.3,170.8 -2.5,2 -16.7,7.3 -22.5,7.9 1.9,-2.9 6.8,-13 6.2,-24.9 -6.7,16.4 -30.5,28.6 -43.7,33.1 22.8,-16.5 49,-62.5 53.5,-85.1 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path477-59"
+           d="m 291.9,167.7 c 0,0 2.5,37.5 -16.4,67.5 5.1,-28.3 -4.8,-46.1 -4.8,-46.1 0,0 -1.4,15.3 -7.4,30.1 -10.4,25.5 -19.8,30.7 -23.5,28 -8,31.7 -60.9,30.2 -60.9,30.2 12,3 54.1,5.3 85,-17.4 -1.7,4 -11.2,23.1 -34,32.9 22.5,-1.4 52.2,-25.2 57.5,-40.9 0.4,11.8 -3.4,20 -5.9,24.7 37.5,-42 10.4,-109 10.4,-109 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path479-3"
+           d="m 172.6,298.2 c 19.6,-1.8 35.6,-6.2 46.4,-20.4 -17.7,3 -31.7,1.7 -40.4,-0.3 0,0 13.9,0.6 31.5,-3.9 20.4,-5.1 45.7,-17 60.2,-44.3 -0.7,65 -66.6,77.9 -97.7,68.9 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path481-5"
+           d="M 46.7,52.2 C 46.3,51.6 46.3,53.6 45.9,53 43.2,48.2 41,40 40.7,34.2 c 0,0 -4.4,2.5 -7.2,11.5 -0.5,1.6 -0.9,2.5 -1.2,3.4 -0.1,0.3 0.2,-2.9 0.1,-2.6 -0.5,1.1 -2.1,2.9 -2.6,4.9 -0.4,1.6 -1,2.5 -1.3,4.5 C 28.4,56.5 28.4,53.5 28.3,54 21.3,71.6 22.1,97.3 23,96.2 39.6,74.6 60.5,67.7 60.5,67.7 58,66 52.6,61.7 46.7,52.2 Z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path483-7"
+           d="m 163.1,117.3 c 1.4,-1.1 6.3,-5.6 7.5,-10.9 -0.9,0.4 -1,-0.7 -2,-0.2 -1.8,1.9 -6.2,6.5 -11.4,9.8 1.4,-1.3 3.9,-3.2 4.5,-4.2 -5.6,3.9 -12.5,6.6 -17.9,6 -0.8,0 4,0.5 8.2,-2.8 -4.1,1.9 -11.1,1.7 -11.8,1.5 -0.6,-0.2 6.9,-1 6.2,-1.2 -3.5,-1.2 -8.1,-0.4 -9.1,0.1 -1.9,0.9 -3.8,2.2 -5.2,3.9 0.8,-1 1.1,-1.9 2,-3.4 -2.6,2.5 -6.2,5.2 -6.7,5.3 0.4,-0.8 6.3,-5.3 5.2,-4.9 -0.7,0.7 -3.2,2.1 -4.9,3.4 -0.5,0.3 3.5,-3.3 3.1,-3 -6.7,1.7 -6,5.4 -6.2,5.5 0.1,0.2 0.1,0.7 0.3,0.9 0.8,2.4 3.7,6.5 6.4,10.4 2,2.4 2.6,5.1 2.7,4.2 0.9,-4.4 27.2,-18.9 29.1,-20.4 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path485-0"
+           d="m 169.2,107.6 c -0.2,0 -0.4,-3.2 -0.1,-2.4 0.2,0.7 -0.3,7.2 -6.2,11 -1.3,0.8 -0.1,-2.1 -1.5,-0.6 -2.3,2.5 -8,10.8 -22.3,10.8 -0.5,0 5.6,-2.7 4.9,-2.5 -1.5,0.4 -3.2,0.9 -8.8,2.7 -0.5,0.2 4.7,-3.2 4.2,-3.1 -0.7,0.2 -3.8,2.3 -7.6,3.9 1.8,-1.8 3.9,-3.6 3.2,-3.3 -3,1.7 -5.2,3.6 -6.5,5.5 0.9,1.5 2,2.4 2.8,3.9 2,2.4 2.2,4.9 2.7,4.2 5.3,-6.4 26.2,-16.1 30.9,-21.1 4.8,-5.2 2.9,-4.4 4.3,-9 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path487-8"
+           d="M 138.2,252.4 C 111.3,244 80.6,231.6 78.2,196.3 75,150 117.6,155 117.6,155 c -1.5,0.6 -4.8,4 -5.9,7.9 -1.2,4.2 -3.4,12.4 6.2,20.9 15.2,13.4 -25,38.3 43.5,70.1 1.7,0.7 -15.3,1 -23.2,-1.5 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path489-1"
+           d="m 171.4,108.2 c 1.2,-3 2.6,-10 -1.4,-11.5 -3.3,-0.8 -6.2,-1.4 -11.6,-1.3 1.8,0.4 7,1.5 8.3,3.9 2.6,4.6 0.5,13.6 -0.4,15.9 2.7,-2.1 3.9,-4.1 5.1,-7 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path491-9"
+           d="m 127.5,229.9 c 18.8,4.5 40,1.3 52.1,-7 8.1,-5.6 19.8,-13.9 25.1,-13 -6,-1.7 -10.6,-2.4 -15.9,-2.1 -1,0 -1.9,0.1 -2.9,0.2 -1.8,0.2 -3.7,0.4 -5.8,0.8 -3.2,0.7 -6.7,3.1 -10,3.1 -0.2,0 3.1,-1.7 2.8,-1.7 -1.7,0.5 -3.6,0.8 -5.6,1.3 -1.2,0.3 -2.4,0.5 -3.6,0.7 -37.7,7 -72.2,-13.5 -72.2,-13.5 -1.9,9.5 14.9,26.2 36,31.2 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path493-9"
+           d="m 289.2,78.5 c 0,0 14.4,15.5 21.2,30.3 6.8,14.8 8.9,31.6 8.9,31.6 0,0 1,-14.1 -6.8,-37.8 -8.4,-25.7 -25,-47.7 -41.4,-59.8 -11,-8.3 -33.1,-19.3 -33.1,-19.3 0,0 38.1,22.6 51.2,55 z" />
+        <path
+           style="opacity:0.1;fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path495-78"
+           d="m 81.2,75.2 c 0.2,0 -7.1,0.9 -20,12.2 -5.5,4.5 -9.9,8.9 -13.3,12.7 -9.4,11.4 -14.9,22.4 -14.9,22.4 0,0 0.8,-6.8 5.1,-16.2 -13.7,21.6 -18.9,53 -18.9,53 0,0 -0.8,-14.3 2.8,-31.1 -1.4,3.9 -3.1,9.4 -4,16.7 -2.7,22 0,41.3 0,41.3 0,0 -1.2,-4.2 -2.5,-10.2 0.5,4.4 1.2,9.6 2.4,15.5 4.3,20.8 12.4,40.5 12.4,40.5 0,0 -10,-13.5 -16.6,-34.1 1.2,6.3 3.1,14.1 5.7,23.5 8.2,28.5 19.1,43.3 19.1,43.3 0,0 -8.4,-7.4 -19.3,-34.9 C 14.4,217.6 11.9,206 10.3,197.4 9.4,191.1 8.6,185.3 7.8,176.9 7.5,174 7.1,170.6 7.1,167.8 c -2.4,11.4 -3.9,21.1 -3.9,21.1 0,0 0.6,-22.8 4.3,-43.4 0.6,-3.1 1.3,-6 2.2,-8.8 -3.5,6.7 -6.2,12.3 -6.2,12.3 0,0 4.6,-12.8 9,-23.5 -4.4,7.9 -7,14.4 -7,14.4 0,0 7.7,-26.4 16.9,-39.7 5,-7.2 10,-12.1 13.6,-15.1 1.2,-1.2 2.4,-2.3 3.7,-3.2 1.3,-1 2.7,-2 3.9,-2.9 0.6,-0.5 1.3,-1 2,-1.5 12.4,-9.2 25.7,-11.4 30.2,-10.9 0.1,0 -3.9,0.2 -12.5,4.8 4.2,-1.5 7.6,-2 9.6,-1.9 0.1,0 -3,0.7 -10.1,5.3 9.2,-4.5 17.6,-5.7 21,-5.3 0.2,0 -6.5,0.4 -20.5,9.5 -0.4,0.3 -0.8,0.5 -1.2,0.8 8.4,-3.7 16,-4.7 19.1,-4.6 z m -39.4,79 c -2.5,1.2 -5.4,10.8 -3.1,32.5 1.9,17.7 9.3,27.1 9.3,27.1 0,0 -3.8,-7.1 -6.1,-31.5 -2,-21 -0.3,-27.8 -0.1,-28.1 z m 6.9,-16.7 c -3.4,17.8 1.2,42.9 1.2,42.9 0,0 -0.8,-21.1 3.8,-43 4.8,-23.4 12,-30.3 12.1,-30.1 -3.9,0.4 -13.7,12.4 -17.1,30.2 z m 9.2,-44.8 c -2.1,2.2 -3.9,4.6 -5.4,7.1 -5.6,5.5 -12,16.4 -15.2,31.5 -6,29.3 -1.7,47 -1.7,47 0,0 -0.1,-27.1 6.3,-50.3 0.9,-3.3 1.8,-6.3 2.8,-9 -1.6,6.6 -2,11.5 -2,11.5 0,0 5.2,-21.4 23.6,-39.7 C 77.9,79.2 85.8,76.9 85.9,77 c -8.6,1 -19.4,6.5 -28,15.7 z m -6.7,62.8 c -1.2,13 1.1,26.4 1.1,26.4 0,0 -0.2,-13.5 1.5,-28.7 1.7,-15.1 4,-20.9 4.1,-20.8 -2.8,1.5 -5.8,13.7 -6.7,23.1 z m 1.4,-44.1 c -5.9,10.2 -7.9,20.3 -7.9,20.3 0,0 7.4,-16.8 12.5,-24.1 5.1,-7.3 10.1,-12.1 10.1,-12 -3.1,1.3 -9.7,5.9 -14.7,15.8 z m -26.3,37.8 c -2.5,1 -6.1,10.5 -5.1,32.3 0.8,17.7 7.6,27.6 7.6,27.6 0,0 -3.3,-7.3 -4.1,-31.8 m 105.4,-128 c 0,0 -12.1,4.4 -18.9,13.1 -6.8,8.7 -8.1,17.7 -8.1,17.7 0,0 7.5,-20 27,-30.8 z m -8.5,11.1 c -8.7,11.5 -10.8,19.8 -10.8,19.8 0,0 9.7,-22.9 34.1,-32.7 0,0.1 -14.6,1.5 -23.3,12.9 z M 34.1,58.5 c 1.5,-13.4 5.3,-21.3 5.3,-21.3 0,0 -12.5,18.9 -5,42 0,0.1 -1.8,-7.3 -0.3,-20.7 z m 9.4,16.1 c 0,0 -2.8,-6.2 -3.9,-17.6 -1.1,-11.5 0.8,-18.5 0.8,-18.5 0,0 -7.5,17 3.1,36.1 z" />
+        <path
+           style="opacity:0.5;fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path497-2"
+           d="m 208.4,198.6 c -1.8,-2.4 -9.6,-8.1 -18.3,-8.7 -11.6,-0.8 -21,4.2 -21,4.2 0,0 6.4,-3.7 21.2,-2.4 10.2,0.9 18,6.6 18.1,6.9 z" />
+        <path
+           style="opacity:0.5;fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path499-5"
+           d="m 212.3,203.2 c -1.8,-2.5 -8.4,-8.3 -19,-10.4 -13.5,-2.6 -23.4,3.1 -23.4,3.1 0,0 7.7,-3.2 23.3,-0.7 10.7,1.8 18.9,7.8 19.1,8 z" />
+        <path
+           style="opacity:0.5;fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path501-3"
+           d="m 208.5,203.3 c -1.5,-1.4 -4.9,-3.8 -10.8,-5.5 -9.5,-2.7 -15.9,-0.2 -15.9,-0.2 0,0 3.8,-0.9 13.5,1 6,1.2 13.1,4.6 13.2,4.7 z" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path503-4"
+           d="m 330.5,259 c -1.9,3.6 -4.4,7.5 -7.7,11.5 -8.1,10 -18.3,17.9 -26.7,23.6 -3.4,2.3 -6.7,4.3 -10,6 l -0.1,-1.2 -0.1,0 c 9.7,-5.1 20.2,-12 31,-22.6 6.4,-6.3 10.7,-12 13.6,-17.3 z M 33.1,47.6 c 0.4,-0.9 0.7,-1.8 1.2,-3.4 0.6,-1.8 1.2,-3.4 1.9,-4.7 -0.9,1.6 -1.9,3.6 -2.7,6.2 -0.2,0.5 -0.3,0.9 -0.4,1.3 z m 104.3,285.5 c 0,0 1.4,1.3 3.8,2.9 9.2,2.6 30.1,7.9 46.5,7.3 -2,-0.4 -3.6,-0.9 -4.7,-1.5 -20.8,-0.7 -45.6,-8.7 -45.6,-8.7 z M 9.6,138.4 c -0.5,0.8 -0.9,1.7 -1.4,2.5 0.1,-0.1 0.1,-0.2 0.2,-0.3 -4.2,13 -7.4,33.1 -5.4,63 0,-0.2 0.1,-0.6 0.1,-1.2 0,0.4 0,0.7 0.1,1.1 0,-0.4 0.2,-2.1 0.6,-4.7 -1.5,-28.6 1.7,-47.9 5.8,-60.4 z M 28.8,254.7 C 13.1,227.8 8.3,203 7.2,182.9 7,184 6.7,185.1 6.5,186.1 c 1.3,19.8 6.2,44 21.5,70 12,20.5 43.5,68.1 122.6,85.9 -3.6,-1 -6.7,-2.5 -9,-3.9 C 69.7,318.9 40.3,274.4 28.8,254.7 Z m 253.9,51.8 c 0.3,-0.3 0.8,-0.9 0.9,-0.9 -26.5,36.2 -103.2,31.8 -103.2,31.8 0,0 0.3,0.7 1.3,1.6 10.9,0.3 62.8,0.7 91.3,-21.8 7.1,-5.3 11.7,-11.5 13.2,-17.1 0,0 -0.1,0.1 -0.4,0.2 -0.7,2.4 -2,4.6 -3.1,6.2 z M 16.8,105.9 C 11,115.8 4.9,132.1 0,159.4 c 0,0 0.1,-0.4 0.4,-1.1 -0.1,0.3 -0.1,0.7 -0.2,1 0,0 0.4,-1.1 1.1,-3.1 4.2,-23.3 9.4,-38.4 14.5,-48.3 0.2,-0.5 0.6,-1.2 1,-2 z M 29.4,54.2 c 0.2,-1.9 0.9,-2.8 1.2,-4.3 0.1,-0.4 0.3,-0.9 0.5,-1.3 -0.5,0.8 -1,1.7 -1.2,2.7 -0.2,0.6 -0.4,1.2 -0.6,1.7 0,0.4 0,1 0.1,1.2 -0.1,0.1 0,0.1 0,0 z m -5.5,40.4 c 0,-0.9 -0.1,-1.8 -0.1,-2.7 -0.8,-11.9 0.6,-21.2 1.9,-28 0.8,-3.5 1.7,-6.7 2.7,-9.6 0,-0.2 0,-0.4 -0.1,-0.4 l -0.1,0 c -0.2,0.5 -0.4,1.1 -0.6,1.6 0,0.1 -0.1,0.2 -0.1,0.3 -0.1,0.3 -0.2,0.5 -0.3,0.8 -0.3,0.9 -0.6,1.8 -0.9,2.8 -0.4,1.5 -0.8,3 -1.2,4.6 0,0.2 -0.1,0.4 -0.1,0.6 -0.1,0.2 -0.1,0.5 -0.2,0.7 0,0.1 0,0.2 -0.1,0.4 -0.7,3.1 -1.2,6.5 -1.6,10.2 -1.2,10.2 -0.9,18.8 -0.4,20.1 0.5,-0.5 0.8,-0.9 1.2,-1.4 z M 286,298.9 c -0.6,0.3 -5.6,2.9 -13.8,6.3 -15.4,6.4 -26,11.3 -26.9,13 0,0 4,-2.7 17.7,-8.2 14.3,-5.7 21.1,-9 22.8,-9.8 0.3,-0.1 0.4,-0.2 0.4,-0.2 z" />
+        <path
+           style="opacity:0.1;fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path505-9"
+           d="m 154.4,321.9 c 0,0 -0.1,0 0,0 m 0,-0.9 c 1,2.5 10.5,6.1 32.3,5.1 17.7,-0.8 27.6,-7.6 27.6,-7.6 0,0 -7.3,3.3 -31.8,4.2 -21.2,0.6 -27.8,-1.5 -28.1,-1.7 z M 141,314.1 c 17.7,3.9 39.7,0.5 39.7,0.5 0,0 -21.1,0.2 -42.9,-5 -23.3,-5.5 -29.9,-12.9 -29.8,-13 0.4,4 15.3,13.6 33,17.5 z m 14.9,-1.5 c 12.9,1.6 26.4,-0.3 26.4,-0.3 0,0 -13.5,-0.2 -28.7,-2.3 -15,-2.1 -20.7,-4.5 -20.7,-4.7 1.5,2.8 13.6,6.1 23,7.3 z m -43.8,-2.5 c 10.5,5.2 20.7,6.6 20.7,6.6 0,0 -17.2,-6.3 -24.9,-10.9 -7.6,-4.6 -13.8,-8.6 -14,-9 1.7,3 8.1,8.9 18.2,13.3 z m 36.8,27.2" />
+        <path
+           style="fill:#000025;fill-opacity:0.01568627"
+           inkscape:connector-curvature="0"
+           id="path507-0"
+           d="m 100.9,67 c 0,0 -2.7,3.2 -4.7,6.4 -2.3,3.5 -4.2,7.2 -4.2,7.2 0,0 -11.4,-8.4 -21.6,-10.1 -10.2,-1.7 -13.2,-1.4 -13.2,-1.4 0,0 17,-8.8 43.7,-2.1 z" />
+      </g>
+      <g
+         id="g7"
+         transform="matrix(0.41631905,0,0,0.41631907,18.45601,66.220631)">
+        <radialGradient
+           id="radialGradient4464"
+           cx="-14374.85"
+           cy="9397.75"
+           r="450.875"
+           fx="-14403.608"
+           fy="9397.75"
+           gradientTransform="matrix(0.762,0.034,0.05,-1.12,11426.936,11262.421)"
+           gradientUnits="userSpaceOnUse">
+          <stop
+             offset="4.500000e-02"
+             style="stop-color:#FFEA00"
+             id="stop4466" />
+          <stop
+             offset="0.12"
+             style="stop-color:#FFDE00"
+             id="stop4468" />
+          <stop
+             offset="0.254"
+             style="stop-color:#FFBF00"
+             id="stop4470" />
+          <stop
+             offset="0.429"
+             style="stop-color:#FF8E00"
+             id="stop4472" />
+          <stop
+             offset="0.769"
+             style="stop-color:#FF272D"
+             id="stop4474" />
+          <stop
+             offset="0.872"
+             style="stop-color:#E0255A"
+             id="stop4476" />
+          <stop
+             offset="0.953"
+             style="stop-color:#CC2477"
+             id="stop4478" />
+          <stop
+             offset="1"
+             style="stop-color:#C42482"
+             id="stop4480" />
+        </radialGradient>
+        <path
+           class="st0"
+           d="m 805.3,93.6 c -23.9,27.9 -35.1,90.6 -10.8,154.3 24.3,63.7 61.5,49.8 84.7,114.7 30.6,85.6 16.4,200.6 16.4,200.6 0,0 36.8,106.6 62.5,-6.6 56.7,-212.9 -152.8,-410.7 -152.8,-463 z"
+           id="path26"
+           style="fill:url(#SVGID_1_)"
+           inkscape:connector-curvature="0" />
+        <linearGradient
+           id="linearGradient4483"
+           gradientUnits="userSpaceOnUse"
+           x1="575.64893"
+           y1="294.80591"
+           x2="384.21091"
+           y2="921.03387"
+           gradientTransform="matrix(1,0,0,-1,0,1026)">
+          <stop
+             offset="0"
+             style="stop-color:#000F43;stop-opacity:0.4"
+             id="stop4485" />
+          <stop
+             offset="0.485"
+             style="stop-color:#001962;stop-opacity:0.173"
+             id="stop4487" />
+          <stop
+             offset="1"
+             style="stop-color:#002079;stop-opacity:0"
+             id="stop4489" />
+        </linearGradient>
+        <path
+           class="st1"
+           d="m 845.7,805.6 c -9.6,6.8 -19.7,12.8 -30.1,18.2 13.9,-20.3 26.6,-41.3 38.3,-63 9.5,-10.5 18.1,-20.6 25.2,-31.7 3.4,-5.4 7.3,-12.1 11.4,-19.8 24.9,-44.9 52.4,-117.6 53.2,-192.2 l 0,-0.1 c 0,-1.8 0,-3.7 0,-5.5 0.1,-18.7 -1.8,-37.4 -5.7,-55.7 0.2,1.4 0.4,2.9 0.6,4.3 -0.2,-1.1 -0.4,-2.2 -0.6,-3.3 0.4,2 0.7,4 1,6 5.1,43.2 1.5,85.4 -16.7,116.4 -0.3,0.5 -0.6,0.9 -0.9,1.3 9.4,-47.2 12.6,-99.4 2.1,-151.6 0,0 -4.2,-25.4 -35.4,-102.4 -18,-44.4 -49.8,-80.7 -78,-107.2 C 785.4,188.8 763,168.3 750.6,155.2 724.8,128 714,107.6 709.5,94.3 c -3.9,-1.9 -53.1,-49.8 -57,-51.6 -21.5,33.4 -89.2,137.7 -57,235.1 14.6,44.2 51.5,90 90.1,115.7 1.7,1.9 23,25 33.1,77.2 10.4,53.8 5,95.9 -16.5,158 -25.3,54.5 -90.1,108.4 -150.7,113.9 -129.7,11.8 -177.1,-65.1 -177.1,-65.1 46.3,18.5 97.6,14.7 128.7,-4.6 31.4,-19.4 50.4,-33.8 65.8,-28.1 15.2,5.7 27.3,-10.8 16.4,-27.8 -17.1,-26.4 -48.4,-40 -79.4,-34.6 -31.4,5.1 -60.2,30 -101.4,5.9 -2.7,-1.5 -5.2,-3.2 -7.7,-5.1 -2.7,-1.8 8.8,2.7 6.1,0.7 -8,-4.4 -22.2,-13.8 -25.9,-17.2 -0.6,-0.6 6.2,2.2 5.6,1.6 -38.5,-31.7 -33.7,-53.1 -32.5,-66.6 1,-10.7 8,-24.5 19.8,-30.1 5.7,3.1 9.2,5.5 9.2,5.5 0,0 -2.4,-5 -3.7,-7.6 0.5,-0.2 0.9,-0.1 1.4,-0.3 4.7,2.3 15,8.1 20.4,11.7 7.1,5 9.3,9.4 9.3,9.4 0,0 1.9,-1 0.5,-5.4 -0.5,-1.8 -2.6,-7.5 -9.7,-13.2 l 0.4,0 c 4.2,2.4 8.2,5.1 11.9,8.2 2,-7.2 5.5,-14.7 4.7,-28.1 -0.5,-9.4 -0.3,-11.9 -1.9,-15.5 -1.5,-3.1 0.8,-4.3 3.4,-1.1 -0.4,-2.5 -1.2,-5 -2.2,-7.4 l 0,-0.2 c 3.2,-11.2 68.2,-40.5 73,-43.9 7.8,-5.5 14.3,-12.6 19.1,-20.8 3.6,-5.8 6.3,-13.8 7,-26.1 0.4,-8.8 -3.8,-14.7 -69.5,-21.6 -18,-1.8 -28.5,-14.8 -34.5,-26.8 -1.1,-2.6 -2.2,-4.9 -3.3,-7.3 -1.1,-2.7 -1.9,-5.6 -2.6,-8.4 10.7,-30.9 28.8,-57 55.4,-76.7 1.4,-1.3 -5.8,0.3 -4.3,-1 1.7,-1.5 12.7,-6 14.8,-7 2.5,-1.2 -10.9,-6.9 -22.7,-5.5 -12.1,1.4 -14.6,2.8 -21.1,5.5 2.7,-2.7 11.2,-6.1 9.2,-6.1 -13,2 -29.2,9.6 -43,18.1 0,-1.5 0.3,-3 0.8,-4.3 -6.4,2.7 -22.3,13.8 -26.9,23.1 0.2,-1.8 0.3,-3.6 0.3,-5.4 -4.9,4.1 -9.3,8.7 -13.2,13.8 l -0.2,0.2 c -37.4,-15.1 -70.2,-16 -98.1,-9.3 -6.1,-6.1 -9.1,-1.6 -22.9,-32.1 -0.9,-1.8 0.7,1.8 0,0 -2.3,-5.9 1.4,7.9 0,0 -23.3,18.4 -53.9,39.2 -68.6,53.9 -0.2,0.6 17.2,-4.9 0,0 -6,1.7 -5.6,5.3 -6.5,37.5 -0.2,2.4 0,5.2 -0.2,7.4 -11.7,15 -19.7,27.6 -22.8,34.2 -15.2,26.2 -31.9,67 -48.1,131.6 7.2,-17.5 15.8,-34.4 25.8,-50.4 C 97,434.5 84,488.3 81.4,571.1 c 3.3,-17.1 7.4,-34 12.5,-50.7 -3.2,68.7 8.7,137.4 34.7,201.1 9.3,22.8 24.8,57.5 51,95.4 C 261.9,904 378.3,958 507.2,958 641.8,958 762.6,899.1 845.7,805.6 Z"
+           id="path35"
+           style="fill:url(#SVGID_2_)"
+           inkscape:connector-curvature="0" />
+        <radialGradient
+           id="radialGradient4492"
+           cx="-8291.3574"
+           cy="7620.0073"
+           r="266.88599"
+           gradientTransform="matrix(1.219,0.123,0.123,-1.219,10197.618,10946.078)"
+           gradientUnits="userSpaceOnUse">
+          <stop
+             offset="3.000000e-03"
+             style="stop-color:#FFEA00"
+             id="stop4494" />
+          <stop
+             offset="0.497"
+             style="stop-color:#FF272D"
+             id="stop4496" />
+          <stop
+             offset="1"
+             style="stop-color:#C42482"
+             id="stop4498" />
+        </radialGradient>
+        <path
+           class="st2"
+           d="M 746.1,868.7 C 909,849.8 981.1,682 888.5,678.7 804.8,676 669,877.6 746.1,868.7 Z"
+           id="path44"
+           style="fill:url(#SVGID_3_)"
+           inkscape:connector-curvature="0" />
+        <radialGradient
+           id="radialGradient4501"
+           cx="-8315.5039"
+           cy="7875.9189"
+           r="445.67801"
+           gradientTransform="matrix(1.219,0.123,0.123,-1.219,10197.618,10946.078)"
+           gradientUnits="userSpaceOnUse">
+          <stop
+             offset="3.000000e-03"
+             style="stop-color:#FFE900"
+             id="stop4503" />
+          <stop
+             offset="0.157"
+             style="stop-color:#FFAF0E"
+             id="stop4505" />
+          <stop
+             offset="0.316"
+             style="stop-color:#FF7A1B"
+             id="stop4507" />
+          <stop
+             offset="0.472"
+             style="stop-color:#FF4E26"
+             id="stop4509" />
+          <stop
+             offset="0.621"
+             style="stop-color:#FF2C2E"
+             id="stop4511" />
+          <stop
+             offset="0.762"
+             style="stop-color:#FF1434"
+             id="stop4513" />
+          <stop
+             offset="0.892"
+             style="stop-color:#FF0538"
+             id="stop4515" />
+          <stop
+             offset="1"
+             style="stop-color:#FF0039"
+             id="stop4517" />
+        </radialGradient>
+        <path
+           class="st3"
+           d="M 900.2,644.4 C 1012.3,579.2 983,438.3 983,438.3 c 0,0 -43.2,50.2 -72.6,130.3 -29,79.4 -77.6,115.2 -10.2,75.8 z"
+           id="path63"
+           style="fill:url(#SVGID_4_)"
+           inkscape:connector-curvature="0" />
+        <radialGradient
+           id="radialGradient4520"
+           cx="-8252.4678"
+           cy="7462.7832"
+           r="408.95801"
+           gradientTransform="matrix(1.219,0.123,0.123,-1.219,10197.618,10946.078)"
+           gradientUnits="userSpaceOnUse">
+          <stop
+             offset="3.000000e-03"
+             style="stop-color:#FF272D"
+             id="stop4522" />
+          <stop
+             offset="0.497"
+             style="stop-color:#C42482"
+             id="stop4524" />
+          <stop
+             offset="0.986"
+             style="stop-color:#620700"
+             id="stop4526" />
+        </radialGradient>
+        <path
+           class="st4"
+           d="M 544.5,952.1 C 700.7,1002 835,878.9 752.2,837.8 677,800.7 470.3,928.5 544.5,952.1 Z"
+           id="path72"
+           style="fill:url(#SVGID_5_)"
+           inkscape:connector-curvature="0" />
+        <radialGradient
+           id="radialGradient4529"
+           cx="750.18903"
+           cy="629.95898"
+           r="782.17999"
+           fx="778.1665"
+           fy="616.13037"
+           gradientTransform="matrix(1,0,0,-1,0,1026)"
+           gradientUnits="userSpaceOnUse">
+          <stop
+             offset="0.156"
+             style="stop-color:#FFEA00"
+             id="stop4531" />
+          <stop
+             offset="0.231"
+             style="stop-color:#FFDE00"
+             id="stop4533" />
+          <stop
+             offset="0.365"
+             style="stop-color:#FFBF00"
+             id="stop4535" />
+          <stop
+             offset="0.541"
+             style="stop-color:#FF8E00"
+             id="stop4537" />
+          <stop
+             offset="0.763"
+             style="stop-color:#FF272D"
+             id="stop4539" />
+          <stop
+             offset="0.796"
+             style="stop-color:#F92433"
+             id="stop4541" />
+          <stop
+             offset="0.841"
+             style="stop-color:#E91C45"
+             id="stop4543" />
+          <stop
+             offset="0.893"
+             style="stop-color:#CF0E62"
+             id="stop4545" />
+          <stop
+             offset="0.935"
+             style="stop-color:#B5007F"
+             id="stop4547" />
+        </radialGradient>
+        <path
+           class="st5"
+           d="m 911.8,704.2 c 3.8,-5.4 8.9,-22.5 13.5,-30.2 27.6,-44.5 27.8,-80 27.8,-80.8 C 969.8,510 968.2,476 958,413.2 949.7,362.6 913.7,290.1 882.4,255.2 850.2,219.2 872.9,231 841.7,204.7 814.4,174.4 787.9,144.4 773.4,132.3 669.2,45.1 671.6,26.6 673.6,23.4 c -0.3,0.4 -0.8,0.9 -1.5,1.6 -1.2,-4.9 -2.1,-9.1 -2.1,-9.1 0,0 -57,57 -69,152 -7.8,62 15.4,126.7 49,168 17.5,21.4 37.3,40.9 59,58 l 0,0 c 25.4,36.5 39.4,81.5 39.4,129.9 0,121.2 -98.3,219.5 -219.7,219.5 -16.5,0 -33,-1.8 -49.1,-5.5 C 422.4,726.9 389.3,698 372.8,678.4 363.4,667.2 359.3,659 359.3,659 c 51.3,18.4 108,14.5 142.5,-4.5 34.7,-19.3 55.8,-33.5 72.8,-27.9 16.8,5.6 30.2,-10.7 18.2,-27.5 -11.8,-16.8 -42.4,-41 -87.9,-34.3 -34.8,5.1 -66.7,29.8 -112.2,5.8 -2.9,-1.5 -5.8,-3.2 -8.6,-5 -3,-1.8 9.8,2.7 6.8,0.7 -8.9,-4.3 -24.6,-13.7 -28.6,-17.1 -0.7,-0.6 6.9,2.2 6.2,1.6 -42.6,-31.4 -37.3,-52.7 -36,-66 1.1,-10.7 8.8,-24.3 21.9,-29.9 6.3,3.1 10.2,5.4 10.2,5.4 0,0 -2.7,-4.9 -4.1,-7.5 0.5,-0.2 1,-0.1 1.5,-0.3 5.2,2.2 16.6,8 22.6,11.6 7.8,4.9 10.3,9.4 10.3,9.4 0,0 2.1,-1 0.5,-5.3 -0.6,-1.8 -2.9,-7.4 -10.7,-13.1 l 0.5,0 c 4.6,2.3 9,5.1 13.1,8.2 2.2,-7.1 6.1,-14.6 5.3,-27.9 -0.5,-9.4 -0.3,-11.8 -2.1,-15.4 -1.6,-3.1 0.9,-4.3 3.8,-1.1 -0.5,-2.5 -1.3,-5 -2.4,-7.3 l 0,-0.2 c 3.6,-11.1 75.5,-40.1 80.8,-43.5 8.4,-5.3 15.7,-12.3 21.2,-20.6 4,-5.7 7,-13.7 7.7,-25.9 0.2,-5.5 -1.4,-9.8 -20.5,-14 -11.4,-2.5 -29.1,-4.9 -56.4,-7.5 -19.9,-1.8 -31.6,-14.7 -38.2,-26.6 -1.2,-2.6 -2.4,-4.9 -3.7,-7.2 -1.2,-2.7 -2.1,-5.5 -2.8,-8.4 11.9,-31.2 33.4,-57.8 61.3,-76.1 1.6,-1.3 -6.4,0.3 -4.8,-1 1.9,-1.5 14.1,-5.9 16.4,-6.9 2.8,-1.2 -12,-6.8 -25.2,-5.5 -13.4,1.3 -16.2,2.8 -23.3,5.5 3,-2.6 12.4,-6.1 10.2,-6.1 -14.4,2 -32.3,9.5 -47.6,18 0,-1.5 0.3,-3 0.9,-4.3 -7.1,2.7 -24.6,13.7 -29.7,22.9 0.2,-1.8 0.3,-3.6 0.3,-5.4 -5.4,4 -10.3,8.6 -14.6,13.7 l -0.3,0.2 C 293.1,198 256.7,197 226,203.7 c -6.7,-6.1 -17.6,-15.2 -32.9,-45.4 -1,-1.8 -1.6,3.8 -2.4,2 -6,-13.8 -9.6,-36.4 -9,-52 0,0 -12.3,5.6 -22.5,29.1 -1.9,4.2 -3.1,6.5 -4.3,8.9 -0.6,0.7 1.3,-7.7 1,-7.2 -1.8,3 -6.4,7.2 -8.4,12.6 -1.4,4 -3.3,6.3 -4.6,11.3 l -0.3,0.5 c -0.1,-1.5 0.4,-6.1 0,-5.1 -4.8,9.7 -8.9,19.6 -12.3,29.8 -5.5,18 -11.9,42.6 -12.9,74.6 -0.2,2.4 0,5.1 -0.2,7.3 -13,14.8 -21.9,27.4 -25.2,33.9 -16.8,26 -35.3,66.4 -53.3,130.5 8,-17.5 17.5,-34.2 28.5,-50 -14.9,34 -29.4,87.3 -32.2,169.5 3.6,-17 8.3,-33.8 13.9,-50.2 -2.6,54.8 3.8,122.7 38.4,199.4 20.6,45.1 67.9,136.6 183.6,208.1 l 0,0 c 0,0 39.4,29.3 107,51.3 5,1.8 10.1,3.6 15.2,5.3 -1.6,-0.7 -3.2,-1.3 -4.7,-2.1 45,13.5 91.8,20.4 138.8,20.4 C 702.4,986.3 754,916 754,916 c 0,0 -0.2,0.1 -0.5,0.4 2.5,-2.3 4.9,-4.7 7.1,-7.3 -27.6,26.1 -90.7,27.8 -114.3,25.9 40.2,-11.8 66.7,-21.8 118.2,-41.5 6,-2.2 12.2,-4.8 18.5,-7.6 0.7,-0.3 1.4,-0.6 2.1,-0.9 1.2,-0.6 2.5,-1.1 3.7,-1.7 25.1,-11.8 48.7,-26.6 70.3,-44 51.7,-41.3 62.9,-81.6 68.8,-108.1 -0.8,2.5 -3.4,8.5 -5.2,12.3 -13.3,28.5 -42.8,46 -74.9,60.9 15.3,-20 29.4,-40.9 42.4,-62.4 10.6,-10.6 13.8,-26.9 21.6,-37.8 z"
+           id="path93"
+           style="fill:url(#SVGID_6_)"
+           inkscape:connector-curvature="0" />
+        <radialGradient
+           id="radialGradient4550"
+           cx="691.33899"
+           cy="1022.711"
+           r="923.61499"
+           gradientTransform="matrix(1,0,0,-1,0,1026)"
+           gradientUnits="userSpaceOnUse">
+          <stop
+             offset="0.279"
+             style="stop-color:#FFEA00"
+             id="stop4552" />
+          <stop
+             offset="0.402"
+             style="stop-color:#FFDD00"
+             id="stop4554" />
+          <stop
+             offset="0.63"
+             style="stop-color:#FFBA00"
+             id="stop4556" />
+          <stop
+             offset="0.856"
+             style="stop-color:#FF9100"
+             id="stop4558" />
+          <stop
+             offset="0.933"
+             style="stop-color:#FF6711"
+             id="stop4560" />
+          <stop
+             offset="0.994"
+             style="stop-color:#FF4A1D"
+             id="stop4562" />
+        </radialGradient>
+        <path
+           class="st6"
+           d="m 848.9,803 c 21.1,-23.2 40,-49.8 54.3,-80 36.9,-77.6 94,-206.6 49,-341.3 C 916.8,275.2 868,217 806.1,160.1 705.6,67.8 677.5,26.5 677.5,2 c 0,0 -116.1,129.4 -65.7,264.4 50.4,135 153.5,130 221.7,270.9 80.3,165.7 -64.9,346.6 -185,397.2 7.4,-1.6 267,-60.4 280.6,-208.9 -0.4,2.7 -6.3,43.8 -80.2,77.4 z"
+           id="path108"
+           style="fill:url(#SVGID_7_)"
+           inkscape:connector-curvature="0" />
+        <linearGradient
+           id="linearGradient4565"
+           gradientUnits="userSpaceOnUse"
+           x1="-8974.0137"
+           y1="7777.0605"
+           x2="-8689.6523"
+           y2="7849.5444"
+           gradientTransform="matrix(1.219,0.123,0.123,-1.219,10197.618,10946.078)">
+          <stop
+             offset="0"
+             style="stop-color:#C42482;stop-opacity:0.5"
+             id="stop4567" />
+          <stop
+             offset="0.474"
+             style="stop-color:#FF272D;stop-opacity:0.5"
+             id="stop4569" />
+          <stop
+             offset="0.486"
+             style="stop-color:#FF2C2C;stop-opacity:0.513"
+             id="stop4571" />
+          <stop
+             offset="0.675"
+             style="stop-color:#FF7A1A;stop-opacity:0.72"
+             id="stop4573" />
+          <stop
+             offset="0.829"
+             style="stop-color:#FFB20D;stop-opacity:0.871"
+             id="stop4575" />
+          <stop
+             offset="0.942"
+             style="stop-color:#FFD605;stop-opacity:0.964"
+             id="stop4577" />
+          <stop
+             offset="1"
+             style="stop-color:#FFE302"
+             id="stop4579" />
+        </linearGradient>
+        <path
+           class="st7"
+           d="m 512.6,321.4 c 0.4,-8.8 -4.2,-14.7 -76.7,-21.5 -29.8,-2.8 -41.3,-30.3 -44.7,-41.9 -10.6,27.6 -15,56.5 -12.6,91.5 1.6,22.9 17,47.5 24.4,62 0,0 1.6,-2.1 2.4,-2.9 13.9,-14.4 71.9,-36.4 77.4,-39.5 5.9,-3.9 28.8,-20.7 29.8,-47.7 z"
+           id="path125"
+           style="fill:url(#SVGID_8_)"
+           inkscape:connector-curvature="0" />
+        <linearGradient
+           id="linearGradient4582"
+           gradientUnits="userSpaceOnUse"
+           x1="272.6861"
+           y1="2138.1853"
+           x2="218.11411"
+           y2="2278.0325"
+           gradientTransform="matrix(0.995,0.1,0.1,-0.995,-306.431,2362.0759)">
+          <stop
+             offset="0"
+             style="stop-color:#891551;stop-opacity:0.6"
+             id="stop4584" />
+          <stop
+             offset="1"
+             style="stop-color:#C42482;stop-opacity:0"
+             id="stop4586" />
+        </linearGradient>
+        <path
+           class="st8"
+           d="m 193.3,158.5 c -1,-1.8 -1.6,3.8 -2.4,2 -6,-13.8 -9.6,-36.2 -8.7,-52 0,0 -12.3,5.6 -22.5,29.1 -1.9,4.2 -3.1,6.5 -4.3,8.9 -0.6,0.7 1.3,-7.7 1,-7.2 -1.8,3 -6.4,7.2 -8.3,12.4 -1.7,4.2 -3.3,6.5 -4.6,11.8 -0.4,1.4 0.4,-6.3 0.1,-5.4 C 119.7,203.7 115.2,273 117.7,270 168.2,216.1 226,203.3 226,203.3 c -6.1,-4.5 -19.5,-17.6 -32.7,-44.8 l 0,0 z"
+           id="path132"
+           style="fill:url(#SVGID_9_)"
+           inkscape:connector-curvature="0" />
+        <linearGradient
+           id="linearGradient4589"
+           gradientUnits="userSpaceOnUse"
+           x1="49.2551"
+           y1="337.27731"
+           x2="143.3631"
+           y2="230.3904"
+           gradientTransform="matrix(0.995,0.1,0.1,-0.995,172.704,801.664)">
+          <stop
+             offset="5.000000e-03"
+             style="stop-color:#891551;stop-opacity:0.5"
+             id="stop4591" />
+          <stop
+             offset="0.484"
+             style="stop-color:#FF272D;stop-opacity:0.5"
+             id="stop4593" />
+          <stop
+             offset="1"
+             style="stop-color:#FF272D;stop-opacity:0"
+             id="stop4595" />
+        </linearGradient>
+        <path
+           class="st9"
+           d="M 384.8,722.1 C 315.1,692.3 235.8,650.3 238.8,555 242.9,429.3 356,454.2 356,454.2 c -4.3,1 -15.7,9.2 -19.7,17.8 -4.3,10.8 -12.1,35.3 11.6,60.9 37.1,40.2 -76.2,95.4 98.7,199.6 4.3,2.4 -41.1,-1.5 -61.8,-10.4 l 0,0 z"
+           id="path141"
+           style="fill:url(#SVGID_10_)"
+           inkscape:connector-curvature="0" />
+        <linearGradient
+           id="linearGradient4598"
+           gradientUnits="userSpaceOnUse"
+           x1="227.2766"
+           y1="151.5255"
+           x2="227.3436"
+           y2="226.3065"
+           gradientTransform="matrix(0.995,0.1,0.1,-0.995,172.704,801.664)">
+          <stop
+             offset="0"
+             style="stop-color:#C42482"
+             id="stop4600" />
+          <stop
+             offset="8.299999e-02"
+             style="stop-color:#C42482;stop-opacity:0.81"
+             id="stop4602" />
+          <stop
+             offset="0.206"
+             style="stop-color:#C42482;stop-opacity:0.565"
+             id="stop4604" />
+          <stop
+             offset="0.328"
+             style="stop-color:#C42482;stop-opacity:0.362"
+             id="stop4606" />
+          <stop
+             offset="0.447"
+             style="stop-color:#C42482;stop-opacity:0.204"
+             id="stop4608" />
+          <stop
+             offset="0.562"
+             style="stop-color:#C42482;stop-opacity:9.100000e-02"
+             id="stop4610" />
+          <stop
+             offset="0.673"
+             style="stop-color:#C42482;stop-opacity:2.300000e-02"
+             id="stop4612" />
+          <stop
+             offset="0.773"
+             style="stop-color:#C42482;stop-opacity:0"
+             id="stop4614" />
+        </linearGradient>
+        <path
+           class="st10"
+           d="m 360.1,659.5 c 49.4,17.2 107,14.2 141.5,-4.9 23.1,-12.9 52.7,-33.4 70.9,-28.4 -15.8,-6.2 -27.7,-9.2 -42.1,-9.9 -2.4,0 -5.4,-0.1 -8,-0.3 -5.3,0 -10.5,0.3 -15.8,0.9 -8.9,0.8 -18.8,6.4 -27.7,5.5 -0.5,0 8.7,-3.8 8,-3.6 -4.8,1 -9.9,1.2 -15.4,1.9 -3.5,0.4 -6.4,0.8 -9.9,1 -103,8.7 -190,-55.8 -190,-55.8 -7.5,25 33.1,74.3 88.5,93.6 l 0,0 z"
+           id="path160"
+           style="fill:url(#SVGID_11_)"
+           inkscape:connector-curvature="0" />
+        <linearGradient
+           id="linearGradient4617"
+           gradientUnits="userSpaceOnUse"
+           x1="655.5307"
+           y1="987.87988"
+           x2="961.18671"
+           y2="304.38489"
+           gradientTransform="matrix(1,0,0,-1,0,1026)">
+          <stop
+             offset="0"
+             style="stop-color:#FFF14F"
+             id="stop4619" />
+          <stop
+             offset="0.268"
+             style="stop-color:#FFEE4C"
+             id="stop4621" />
+          <stop
+             offset="0.452"
+             style="stop-color:#FFE643"
+             id="stop4623" />
+          <stop
+             offset="0.612"
+             style="stop-color:#FFD834"
+             id="stop4625" />
+          <stop
+             offset="0.757"
+             style="stop-color:#FFC41E"
+             id="stop4627" />
+          <stop
+             offset="0.892"
+             style="stop-color:#FFAB02"
+             id="stop4629" />
+          <stop
+             offset="0.902"
+             style="stop-color:#FFA900"
+             id="stop4631" />
+          <stop
+             offset="0.949"
+             style="stop-color:#FFA000"
+             id="stop4633" />
+          <stop
+             offset="1"
+             style="stop-color:#FF9100"
+             id="stop4635" />
+        </linearGradient>
+        <path
+           class="st11"
+           d="m 848.7,803.6 c 104.2,-102.3 156.9,-226.6 134.6,-366 0,0 8.9,71.5 -24.8,144.6 16.2,-71.4 18.1,-160.1 -25,-252 C 876,207.6 781.5,143 745.4,116.1 690.7,75.3 668,33.8 667.6,25.2 c -16.3,33.5 -65.8,148.2 -5.3,247 56.6,92.6 145.9,120 208.3,204.9 115.1,156.6 -21.9,326.5 -21.9,326.5 z"
+           id="path181"
+           style="fill:url(#SVGID_12_)"
+           inkscape:connector-curvature="0" />
+        <linearGradient
+           id="linearGradient4638"
+           gradientUnits="userSpaceOnUse"
+           x1="715.88519"
+           y1="594.78992"
+           x2="571.09821"
+           y2="206.0399"
+           gradientTransform="matrix(1,0,0,-1,0,1026)">
+          <stop
+             offset="0"
+             style="stop-color:#FF8E00"
+             id="stop4640" />
+          <stop
+             offset="4.000000e-02"
+             style="stop-color:#FF8E00;stop-opacity:0.858"
+             id="stop4642" />
+          <stop
+             offset="8.400000e-02"
+             style="stop-color:#FF8E00;stop-opacity:0.729"
+             id="stop4644" />
+          <stop
+             offset="0.13"
+             style="stop-color:#FF8E00;stop-opacity:0.628"
+             id="stop4646" />
+          <stop
+             offset="0.178"
+             style="stop-color:#FF8E00;stop-opacity:0.557"
+             id="stop4648" />
+          <stop
+             offset="0.227"
+             style="stop-color:#FF8E00;stop-opacity:0.514"
+             id="stop4650" />
+          <stop
+             offset="0.282"
+             style="stop-color:#FF8E00;stop-opacity:0.5"
+             id="stop4652" />
+          <stop
+             offset="0.389"
+             style="stop-color:#FF8E00;stop-opacity:0.478"
+             id="stop4654" />
+          <stop
+             offset="0.524"
+             style="stop-color:#FF8E00;stop-opacity:0.416"
+             id="stop4656" />
+          <stop
+             offset="0.676"
+             style="stop-color:#FF8E00;stop-opacity:0.314"
+             id="stop4658" />
+          <stop
+             offset="0.838"
+             style="stop-color:#FF8E00;stop-opacity:0.172"
+             id="stop4660" />
+          <stop
+             offset="1"
+             style="stop-color:#FF8E00;stop-opacity:0"
+             id="stop4662" />
+        </linearGradient>
+        <path
+           class="st12"
+           d="M 833.8,537.6 C 797.4,462.4 752,429.5 709,394 c 5,7 6.2,9.5 9,14 37.8,40.3 93.6,138.7 53.1,262.1 C 694.9,902.5 390,793.1 358,762.3 370.9,896.8 596,961.1 742.6,873.9 826,795 893.5,660.8 833.8,537.6 Z"
+           id="path208"
+           style="fill:url(#SVGID_13_)"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         style="display:inline;opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5394156;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="M 476.09303,181.89276 57.201494,493.96938 c 23.578,4.7129 53.891796,6.15514 92.835696,6.15514 l 153.70174,0 c 151.0224,0 172.6058,-21.52991 172.6058,-172.41083 l 0,-120.83059 c 0,-8.77497 -0.085,-17.06914 -0.2517,-24.99034 z"
+         id="path989"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Do we know that mozilla is definitely going to change firefox's icon to that which looks like gitlab?
At any rate, the previous icon wasn't good in my opinion. But maybe wait until the change has happened?
We could use this icon for a little while?