### PR TITLE
Fix mimetype/48 warning in .xsession-errors

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -203,6 +203,10 @@ Type=Fixed
 Size=32
 Type=Fixed
 
+[mimetypes/48]
+Size=48
+Type=Fixed
+
 [mimetypes/scalable]
 Context=Mimetypes
 Size=512


### PR DESCRIPTION
Fixes this repeated error - `Theme directory mimetypes/48 of theme suru-plus-20.2.0 has no size field` 

Distro - Mint 19 Cinnamon (Ubuntu 18.04 base)