### PR TITLE
Fix emotes symbolic name in  the index directories listing

### DIFF
--- a/Suru++-Ubuntu/index.theme
+++ b/Suru++-Ubuntu/index.theme
@@ -22,7 +22,7 @@ PanelSizes=16,22,32,48,64,128,256
 DialogDefault=32
 DialogSizes=16,22,32,48,64,128,256
 
-Directories=actions/16,actions/22,actions/24,actions/32,actions/scalable,actions/symbolic,animations/16,animations/24,apps/16,apps/24,apps/scalable,apps/symbolic,categories/16,categories/24,categories/32,categories/scalable,categories/symbolic,devices/16,devices/24,devices/32,devices/scalable,devices/symbolic,emblems/16,emblems/symbolic,emotes/16,emmoltes/symbolic,mimetypes/16,mimetypes/24,mimetypes/32,mimetypes/scalable,mimetypes/symbolic,places/16,places/24,places/32,places/scalable,places/symbolic,status/16,status/24,status/32,status/scalable,status/symbolic,scalable-max-32/status
+Directories=actions/16,actions/22,actions/24,actions/32,actions/scalable,actions/symbolic,animations/16,animations/24,apps/16,apps/24,apps/scalable,apps/symbolic,categories/16,categories/24,categories/32,categories/scalable,categories/symbolic,devices/16,devices/24,devices/32,devices/scalable,devices/symbolic,emblems/16,emblems/symbolic,emotes/16,emotes/symbolic,mimetypes/16,mimetypes/24,mimetypes/32,mimetypes/scalable,mimetypes/symbolic,places/16,places/24,places/32,places/scalable,places/symbolic,status/16,status/24,status/32,status/scalable,status/symbolic,scalable-max-32/status
 
 [actions/16]
 Context=Actions


### PR DESCRIPTION
Fixes:
(soffice:603586): Gtk-WARNING **: 16:33:42.088: Theme directory emmoltes/symbolic of theme Suru++-Ubuntu has no size field

Closes #80 